### PR TITLE
[cpp6] Fix cpp // processing before # directive

### DIFF
--- a/cpp/cpp.c
+++ b/cpp/cpp.c
@@ -480,6 +480,7 @@ static int pgetc(void)
       if( ch1 == '/' ) /* Double slash style comments */
       {
 	 do { ch = chget(); } while(ch != '\n' && ch != EOF);
+ 	 if (ch == '\n') last_char = '\n';      /* ghaerr fix // before #directive */
 	 return ch;	/* Keep the return. */
       }
 


### PR DESCRIPTION
This fixes a problem with CPP processing // comments prior to any \# directive, such as:
```
// C++ comment at start of line causes following #ifdef SOMETHING to be placed in output
#ifdef SOMETHING
...
```
In the example above, the `#ifdef SOMETHING` would not get processed, and remain in the output .i file. This would then end up getting a unmatched `#endif` from C86.
