### PR TITLE
[c86] Fix mk_stringlit memcmp-based tree search

### DIFF
--- a/compiler/expr.c
+++ b/compiler/expr.c
@@ -529,22 +529,6 @@ static const CHAR *get_stringlit P1 (LABEL, lab)
 }
 #endif /* FORMAT_CHECK */
 
-/* FIXME literal string re-use requires this version on host */
-/* ELKS version happens to work because char is default unsigned on OWC */
-int XXmemcmp(const void *s1, const void *s2, size_t n);
-int XXmemcmp(const void *s1, const void *s2, size_t n)
-{
-    const unsigned char *su1 = s1;
-    const unsigned char *su2 = s2;
-    unsigned char res = 0;  /* FIXME differs between ELKS libc which uses 'char' */
-
-    for (; n > 0; n--)
-        if ((res = *su1++ - *su2++))
-            break;
-
-    return res;
-}
-
 /*
  * mk_ s a string literal and return it's label number.
  *
@@ -573,11 +557,8 @@ static EXPR *mk_stringlit P2 (const CHAR *, s, size_t, len)
 
 	    if (diff >= 0) {
 		result =
-		    XXmemcmp ((const void *) s, (const void *) (p->sptr + diff),
+		    memcmp ((const void *) s, (const void *) (p->sptr + diff),
 			    (size_t) len);
-                /* FIXME above result always >= 0, uses tons of tree->more space */
-                //printf("memcmp %d\n", result);
-                //if (result) result = 1;
 		if (result == 0) {
 		    EXPR   *ep = mk_lcon (p->label);
 
@@ -589,6 +570,7 @@ static EXPR *mk_stringlit P2 (const CHAR *, s, size_t, len)
 		    }
 		    return ep;
 		}
+		result = memcmp(s, p->sptr, len);     /* ghaerr fix tree search */
 	    }
 	    q = p;
 	}


### PR DESCRIPTION
Fixes apparently broken-forever tree search routine in C86's mk_stringlit. It took a while to track this down, but it turns out this routine either didn't work when libc `memcmp` was correct, resulting in no merged strings, or happened to work when libc `memcmp` was a BSD variant that always returned zero or positive by using an `unsigned char` compare for string bytes. It happened to work because the tree was built completely unbalanced, using only p->more nodes.

This in turn showed the ELKS' libc memcmp was correct for ia16-elf-gcc compiler, but incorrect for OpenWatcom, due to the routine using a 'char' variable that defaults to unsigned char in OWC. Long journey.

After figuring all this out, it was found that the C86 tree search routine never actually created a proper sorted tree - which this PR fixes. Combined with an ELKS libc memcmp fix, this will result in a balanced tree search, resulting in marginally faster string literal merging. 