### PR TITLE
[c86] Fix ptr += int and some mul/div code generation/hangs

### DIFF
--- a/compiler/expr.c
+++ b/compiler/expr.c
@@ -3346,10 +3346,17 @@ static EXPR *asnop P0 (void)
 	    if (is_pointer_type (tp) && is_integral_type (ep2->etp)) {
 		check_object (ep1);
 		check_complete (ep1->etp);
+#if 1   /* ghaerr: must cast to int not long when target sizeof(void *) == 2 (8086) */
+		ep2 = explicit_castop (ep2, tp_int);
+		ep3 = mk_icon ((IVAL) referenced_type (tp)->size, tp_int);
+                ep2 = mk_node (en_mul, ep2, ep3, tp_int);
+		ep2 = explicit_castop (ep2, tp);
+#else
 		ep2 = explicit_castop (ep2, tp_long);
 		ep3 = mk_icon ((IVAL) referenced_type (tp)->size, tp_long);
 		ep2 = mk_node (en_mul, ep2, ep3, tp_long);
 		ep2 = explicit_castop (ep2, tp);
+#endif
 	    }
 	    break;
 

--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -86,7 +86,8 @@ static ADDRESS ah_reg = {
 };
 
 static REGTYPE reg_type[] = {
-    (REGTYPE) (D_REG | T_REG | X_REG | N_REG),	/* EAX */
+    /* ghaerr: add Z_REG, required for ax_register; fixes ptr += and imul/idiv hangs */
+    (REGTYPE) (D_REG | T_REG | X_REG | N_REG | Z_REG),	/* EAX */
     (REGTYPE) (D_REG | T_REG | X_REG | N_REG),	/* EDX */
     (REGTYPE) (D_REG | T_REG | Y_REG | C_REG),	/* ECX */
     (REGTYPE) (D_REG | T_REG),	/* EBX */
@@ -2833,7 +2834,7 @@ static ADDRESS *g_cast P4 (ADDRESS *, ap, TYP *, tp1, TYP *, tp2, FLAGS,
 	    ap1 = mk_legal (ap, flags, tp2);
 	    freeop (ap1);
 	    if ((ap1->mode == am_mreg) && (ap1->preg == EAX)) {
-		ap = ax_register ();
+		ap = ax_register ();    /* ghaerr: fix ptr += requires Z_REG or hangs */
 	    } else {
 		ap = data_register ();
 	        g_code (op_mov, IL2, mk_low (ap1), ap);

--- a/compiler/regx86.c
+++ b/compiler/regx86.c
@@ -351,9 +351,12 @@ void validate P1 (const ADDRESS *, ap)
  */
 static REG next_reg P2 (REG, reg, REGTYPE, regtype)
 {
+    int loopcnt = 0;
     for (;;) {
 	if (reg > ST7) {
 	    reg = EAX;
+	    if (++loopcnt > 1)      /* ghaerr: will otherwise hang if no Z_REG in EAX */
+	        FATAL ((__FILE__, "next_reg", "INFINITE LOOP"));
 	}
 	if ((regtypes[reg] & regtype) == regtype) {
 	    return reg;
@@ -524,7 +527,7 @@ ADDRESS *data_register_no_cx P0 (void)
 
 ADDRESS *ax_register P0 (void)
 {
-    return temp_register (Z_REG | T_REG);
+    return temp_register (Z_REG | T_REG);   /* ghaerr: requires Z_REG in reg_type[] */
 }
 
 ADDRESS *axdx_register P0 (void)


### PR DESCRIPTION
Fixes two major C86 compiler bugs: using ptr += n would hang the compiler, and multiply or divide instructions that required the result to be in AX would also hang compilations.

Examples of fixed code:
```
int fs_len;
int *cur; 
int a;
long la;

void f(void)
{
    cur += fs_len;    /* used to hang compiler */

    a = (int)la / 3;  /* used to hang compiler */
}
```

C86 uses an internal cast in the expression tree to convert 'cur' above to an integer, then generates code to add a multiple of the pointer size times fs_len to it, then internally casts 'cur' back to pointer type. This caused a requirement for `ax_register` to be called, which required that the register allocator have a Z_REG capable register available. The first bug is that Z_REG was missing from the register allocator register types.

After fixing that, it was found that the internal cast of 'cur' was to unsigned long, apparently for 386 code generation. This resulted in calls to long helper routines to multiple numbers. Since C86 is 8086 only, the internal cast was changed to int, and the bug was fixed, which interestingly enough, doesn't require the Z_REG register anymore. It was left in for the second bug, below:

The second bug was a hang on an external cast to '(int)' which required a Z_REG register. This was fixed as part of the first bug, and now complex expressions seem to work fine.

These two bug fixes fix two major problems pointed out in the original 8086 toolchain BYU class, where it was suggested that one not use 'long' variables, and also not to use complex expressions in a single statement. It would seem that the reason for these bugs was that complex expressions resulted in the need for Z_REG, which was missing from the register allocator reg_type[] set, so all of these issues should no longer be a problem.

Nonetheless, the register allocator infinite loop now has a loop counter with an error exit, just in case there may be other register allocator problems in the future. This will stop any hangs and terminate the compilation with an internal compiler error message.
