### PR TITLE
[c86] Add support for alloca function, fix extern in .asm file

### DIFF
--- a/compiler/analyze.c
+++ b/compiler/analyze.c
@@ -128,24 +128,18 @@ void addoptinfo P2 (SYM *, sp, STORAGE, sc)
 	    case sc_register:
 		if (regptr < REG_LIST) {
 		    reglst[regptr++] = sp;
-#ifdef VERBOSE
-		    if (verbose_option)
 			DPRINTF (
 			     (DEBUG_GLOBAL, "adding '%s' to reglst\n",
 			      nameof (sp)));
-#endif
 		}
 		break;
 	    case sc_parms:
 	    case sc_auto:
 		if (autoptr < AUTO_LIST) {
 		    autolst[autoptr++] = sp;
-#ifdef VERBOSE
-		    if (verbose_option)
 			DPRINTF (
 			     (DEBUG_GLOBAL, "adding '%s' to autolst\n",
 			      nameof (sp)));
-#endif
 		}
 		break;
 	    default:

--- a/compiler/cglbdef.c
+++ b/compiler/cglbdef.c
@@ -122,7 +122,7 @@ int     internal_option = 0;	/* controls internal debugging options */
 
 #endif /* DEBUG */
 BOOL    lattice_option = FALSE;	/* allow Lattice stype stdarg definitions */
-BOOL    IandD_option = TRUE;	/* separate Instruction and Data segments (ghaerr def ON)*/
+BOOL    IandD_option = TRUE;	/* separate Instruction and Data segments (ghaerr: def ON)*/
 int     lang_option = LANG_C90;	/* C language syntax */
 
 #ifdef LIST
@@ -427,7 +427,7 @@ struct funcs *Funcs = &rosc30_funcs;
 #endif /* MULTIPLE_ASSEMBLERS */
 
 SWITCH *swtables;		/* switch jump tables to be output to the assembler file */
-const CHAR *external_prefix = (const CHAR *) "_"; // -WSF, was: "_";	/* prefix for external/global symbols */
+const CHAR *external_prefix = (const CHAR *) "_"; /* prefix for external/global symbols */
 SIZE    stack_offset = 0L;	/* the number of bytes to remove from the stack */
 SIZE    max_scratch;		/* the maximum number of bytes allocated to temporary variables */
 SIZE    act_scratch;		/* the current number of bytes allocated to temporary variables */

--- a/compiler/expr.c
+++ b/compiler/expr.c
@@ -570,7 +570,7 @@ static EXPR *mk_stringlit P2 (const CHAR *, s, size_t, len)
 		    }
 		    return ep;
 		}
-		result = memcmp(s, p->sptr, len);     /* ghaerr fix tree search */
+		result = memcmp(s, p->sptr, len);     /* ghaerr: fix tree search */
 	    }
 	    q = p;
 	}

--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -2585,8 +2585,12 @@ static ADDRESS *g_fcall P2 (const EXPR *, ep, FLAGS, flags)
 	}
     }
     ap = func_result (flags, size, ep->etp);
-    g_stack(stack_offset);	// Added by WSF; Makes sure stack is restored after function call
-							// This prevents problems when using the stack with inline assemby
+#if 0
+    /* ghaerr: removed, alloca works by not restoring SP after calling it */
+    /* stack restoration is controlled through -stackopt= compiler option */
+    g_stack(stack_offset);  // Added by WSF; Makes sure stack is restored after function call
+                            // This prevents problems when using the stack with inline assemby
+#endif
     return mk_legal (ap, flags, ep->etp);
 }
 

--- a/compiler/getsym.c
+++ b/compiler/getsym.c
@@ -298,7 +298,7 @@ static void nextline P0 (void)
 		*p1++ = *p2++;
 	    }
 	    symstart = bufstart;
-	    act_linetxt = bufstart;	/* ghaerr fix -g source line display */
+	    act_linetxt = bufstart;	/* ghaerr: fix -g source line display */
 	    bufcur = p1 - 1;
 	}
 	/*
@@ -314,7 +314,7 @@ static void nextline P0 (void)
 	    bufstart =
 		(CHAR *) realloc (bufstart, (size_t) (buflen + (SIZE) 1));
 	    bufcur = bufstart + len;
-	    act_linetxt = bufcur;	/* ghaerr fix -g source line display */
+	    act_linetxt = bufcur;	/* ghaerr: fix -g source line display */
 	    symstart = bufstart + len2;
 	}
 	len =
@@ -469,7 +469,7 @@ void initsym P0 (void)
      *      Special names recognised by lower parts of the compiler in
      *      order to do special actions.
      */
-    alloca_name = quick_insert ((const CHAR *) "alloca", (SIZE) 6, tk_id);
+    alloca_name = quick_insert ((const CHAR *) "__alloca", (SIZE) 8, tk_id);
     printf_name = quick_insert ((const CHAR *) "printf", (SIZE) 6, tk_id);
     fprintf_name = quick_insert ((const CHAR *) "fprintf", (SIZE) 7, tk_id);
     sprintf_name = quick_insert ((const CHAR *) "sprintf", (SIZE) 7, tk_id);

--- a/compiler/outgen.c
+++ b/compiler/outgen.c
@@ -64,15 +64,13 @@ const CHAR *outlate P1 (const CHAR *, string)
     const CHAR *sp;
     CHAR   *dp;
 
-#ifdef TRANSLATE
-    int     k;
-
-#endif /* TRANSLATE */
-
     dp = (CHAR *) &symname[0];
+    if (string == alloca_name)
+        return string;          /* ghaerr: don't prefix alloca */
+
     if (*string == (CHAR) '.') {
 #ifdef TRANSLATE
-	//if (!trans_option) {
+	//if (!trans_option) {  /* ghaerr: always remove leading . for SUP_ routines */
 	    //return string;
 	//}
 	/* delete the leading '.' which mucks things up here!! */
@@ -91,6 +89,7 @@ const CHAR *outlate P1 (const CHAR *, string)
 	continue;
 
 #ifdef TRANSLATE
+    int     k;
     if (trans_option && ((k = (int) strlen ((char *) symname)) > 8)) {
 	/*
 	 * translate long symbol name to 8 chars 140603: big prime number

--- a/compiler/outx86_b.c
+++ b/compiler/outx86_b.c
@@ -870,6 +870,9 @@ PRIVATE void put_reference P1 (SYM *, sp)
 	    break;
 	case sc_external:
 	    nl ();
+            if (typeof(sp)->type == bt_func)
+                put_cseg(0);
+            else put_dseg(0);
 	    oprintf ("\t.extern\t%s%s", outlate (nameof (sp)), newline);
 	    break;
 	default:

--- a/compiler/symbol.c
+++ b/compiler/symbol.c
@@ -550,7 +550,7 @@ void endblock P0 (void)
 #endif /* SYNTAX_CORRECT */
 #ifdef CPU_DEFINED
 #ifdef TARGET_NASM
-                    if (Funcs == &nasmx86_func) { /* FIXME kludge fix for NASM: */
+                    if (Funcs == &nasmx86_func) { /* ghaerr: FIXME kludge fix for NASM: */
 		        put_reference (sp);     /* requires global before definition */
 		        put_storage (sp);	/* tentative definition */
                     } else

--- a/libc/c86lib.asm
+++ b/libc/c86lib.asm
@@ -12,8 +12,8 @@
 ;
 ; C86 helper functions
 ;
-        global  alloca
-alloca:
+        global  __alloca
+__alloca:
         pop     bx              ; ret address
         pop     ax              ; alloca size
         sub     sp,ax


### PR DESCRIPTION
Adds support for `alloca` function, which will use libc define for `alloca` and internal `__alloca` to grow stack. Previous comments/work by WSF indicate that not automatically resetting the stack after every function call may interfere with inline functions working properly. TBD.

Fixes incorrect external linkage section in AS86 .asm file for certain extern function declarations.

Removes incorrect VERBOSE defines around DPRINTF; this turns out to be a macOS name collision problem with `dprintf`. 

Relabels compiler fixes as "ghaerr:" for consistency and future searchability.

