### PR TITLE
[c86] Fix 'call ah' compiler bug when calling through function pointer

### DIFF
--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -2573,7 +2573,7 @@ static ADDRESS *g_fcall P2 (const EXPR *, ep, FLAGS, flags)
 	ap = g_expr (ep0, F_AREG);
 	freeop (ap);
 	ap = copy_addr (ap, ap->mode);
-	ap->preg = REG16 (ap->preg);
+	//ap->preg = REG16 (ap->preg);  /* ghaerr: fix call ah bug */
 	break;
     }
     g_code (op_call, IL0, ap, NIL_ADDRESS);

--- a/compiler/outx86_b.c
+++ b/compiler/outx86_b.c
@@ -388,7 +388,7 @@ static struct oplst
     ,				/* op_asm */
 #endif /* ASM */
     {
-    ";.line", 0}
+    "; Line", 0}
     ,				/* op_line */
     {
     (char *) NULL, 0}		/* op_label */
@@ -978,6 +978,7 @@ PRIVATE void put_start P0 (void)
 		 comment, ctime (&time_of_day), newline);
     }
 #endif /* VERBOSE */
+	oprintf("\tUSE16\t86%s", newline);
 }
 
 


### PR DESCRIPTION
Fixes 'call ah' compiler bug reported by @rafael2k when compiling calls through function pointers.

The main compiler was using the REG16 macro to convert to an 8086 register, while the same thing was also being done in the outx86*.c routines.

Adds "USE16 86" at top of generated AS86 .asm file and cleans up '.line' to 'Line' since .line directive not actually used (yet).

Adds C86 -v option (verbose) to examples/Makefile, which shows max memory used.

