### PR TITLE
Fixes required to get ELKS C library compiled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ copy:
 	cp elks-bin/* $(TOPDIR)/elkscmd/rootfs_template/root
 	rm -f $(TOPDIR)/elkscmd/rootfs_template/root/ndisasm86
 	rm -f $(TOPDIR)/elkscmd/rootfs_template/root/nasm86
-	cp libc/*.a $(TOPDIR)/elkscmd/rootfs_template/root
 
 .PHONY: clean cleanobjs
 

--- a/as/const.h
+++ b/as/const.h
@@ -284,7 +284,7 @@ oops - ENTBIT misplaced
 #define SYMLIS_LEN	(sizeof (struct sym_listing_s))
 
 #define FILNAMLEN	64	/* max length of a file name */
-#define LINLEN		512	/* max length of input line */
+#define LINLEN		512	/* max length of input line ghaerr: was 256 */
 #define LINUM_LEN	5	/* length of formatted line number */
 
 #define SPTSIZ		1024	/* number of symbol ptrs */

--- a/as/const.h
+++ b/as/const.h
@@ -284,7 +284,7 @@ oops - ENTBIT misplaced
 #define SYMLIS_LEN	(sizeof (struct sym_listing_s))
 
 #define FILNAMLEN	64	/* max length of a file name */
-#define LINLEN		256	/* max length of input line */
+#define LINLEN		512	/* max length of input line */
 #define LINUM_LEN	5	/* length of formatted line number */
 
 #define SPTSIZ		1024	/* number of symbol ptrs */

--- a/cpp/cpp.c
+++ b/cpp/cpp.c
@@ -803,6 +803,12 @@ static void do_proc_define(void)
 	 {
 	    ch=gettok_nosub();
 	    if( ptr->arg_count==0 && ch == ')' ) break;
+	    if( ch == TK_ELLIPSIS ) {     /* ghaerr: fix varargs handling */
+		 ptr->varargs = 1;
+		 ch=gettok_nosub();
+		 if (ch == ')') break;
+		 if (ch == ',') ch = '*'; /* Force error if not ')' */
+	    }
 	    if( ch == TK_WORD ) 
 	    {
 	       if( cc+strlen(curword)+4 >= len)
@@ -819,11 +825,6 @@ static void do_proc_define(void)
 		  cc++;
 		  ptr->arg_count++;
 		  ch=gettok_nosub();
-		  if( ch == TK_ELLIPSIS ) {
-		     ptr->varargs = 1;
-		     ch=gettok_nosub();
-		     if (ch == ',') ch = '*'; /* Force error if not ')' */
-		  }
 		  if( ch == ')' ) break;
 		  if( ch == ',' ) continue;
 	       }
@@ -856,12 +857,12 @@ static void do_proc_define(void)
 
 #if CPP_DEBUG
       if (cc == 1)
-	 fprintf(stderr, "\n### Define '%s' as null\n", name);
+	 fprintf(stderr, "### Define '%s' as null\n", name);
       else if (ptr->arg_count<0)
-	 fprintf(stderr, "\n### Define '%s' as '%s'\n", 
+	 fprintf(stderr, "### Define '%s' as '%s'\n",
 		 name, ptr->value);
       else
-	 fprintf(stderr, "\n### Define '%s' as %d args '%s'\n", 
+	 fprintf(stderr, "### Define '%s' as %d args '%s'\n",
 		 name, ptr->arg_count, ptr->value);
 #endif
 
@@ -1319,7 +1320,7 @@ void gen_substrings(char *macname, char *data_str, int arg_count, int is_vararg)
 
    if (commas_found || args_found) args_found = commas_found+1;
 
-   if( arg_count == 0 && args_found != 0 )
+   if( !is_vararg && arg_count == 0 && args_found != 0 )    /* ghaerr: fix varargs */
       cerror("Arguments given to macro without them.");
    else if( !is_vararg && arg_count != args_found )
       cwarn("Incorrect number of macro arguments");

--- a/cpp/main.c
+++ b/cpp/main.c
@@ -206,10 +206,11 @@ char * name;
 
    undefine_macro(name);
 
-   ptr = malloc(sizeof(struct define_item) + strlen(value));
+   ptr = malloc(sizeof(struct define_item) + strlen(value)+1);
    if(!ptr) cfatal("Out of memory for macro");
    ptr->name = set_entry(0, name, ptr);
    strcpy(ptr->value, value);
+   strcat(ptr->value, " ");     /* ghaerr: match #define definitions */
    ptr->arg_count = -1;
    ptr->in_use = 0;
    ptr->next = 0;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -39,7 +39,7 @@ show_fonts.o: show_fonts.asm
 
 test: test.o cprintf.o
 	$(LD) $(LDFLAGS) test.o cprintf.o -lc86 -o test
-	cp test $(TOPDIR)/elkscmd/rootfs_template/root
+#	cp test $(TOPDIR)/elkscmd/rootfs_template/root
 
 test.o: test.asm
 	$(AS) $(ASFLAGS) -l test.lst test.asm -o test.o
@@ -52,7 +52,7 @@ test.i: test.c cprintf.h
 
 chess: chess.o
 	$(LD) $(LDFLAGS) chess.o -lc86 -o chess
-	cp chess $(TOPDIR)/elkscmd/rootfs_template/root
+#	cp chess $(TOPDIR)/elkscmd/rootfs_template/root
 
 chess.o: chess.asm
 	$(AS) $(ASFLAGS) -l chess.lst chess.asm -o chess.o

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,9 +6,12 @@ ifndef TOPDIR
 $(error ELKS TOPDIR is not defined)
 endif
 
-C86LIB=../libc
+#C86LIB=../libc
+#INCLUDES=-I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include -I$(C86LIB)/include
 
-INCLUDES=-I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include -I$(C86LIB)/include
+C86LIB=$(TOPDIR)/libc
+INCLUDES=-I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include -I$(C86LIB)/include/c86
+
 DEFINES=
 #DEFINES+=-DNANOPRINTF_IMPLEMENTATION -DNANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS=0 -DNANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS=0
 
@@ -36,6 +39,7 @@ show_fonts.o: show_fonts.asm
 
 test: test.o cprintf.o
 	$(LD) $(LDFLAGS) test.o cprintf.o -lc86 -o test
+	cp test $(TOPDIR)/elkscmd/rootfs_template/root
 
 test.o: test.asm
 	$(AS) $(ASFLAGS) -l test.lst test.asm -o test.o
@@ -46,8 +50,9 @@ test.asm: test.i
 test.i: test.c cprintf.h
 	$(CPP) $(CPPFLAGS) test.c -o test.i
 
-chess: chess.o cprintf.o
-	$(LD) $(LDFLAGS) chess.o cprintf.o -lc86 -o chess
+chess: chess.o
+	$(LD) $(LDFLAGS) chess.o -lc86 -o chess
+	cp chess $(TOPDIR)/elkscmd/rootfs_template/root
 
 chess.o: chess.asm
 	$(AS) $(ASFLAGS) -l chess.lst chess.asm -o chess.o
@@ -55,7 +60,7 @@ chess.o: chess.asm
 chess.asm: chess.i
 	$(CC) $(CFLAGS) chess.i chess.asm
 
-chess.i: chess.c cprintf.h
+chess.i: chess.c
 	$(CPP) $(CPPFLAGS) chess.c -o chess.i
 
 cprintf.o: cprintf.asm

--- a/examples/chess.c
+++ b/examples/chess.c
@@ -1,8 +1,8 @@
 /* From https://github.com/shreejilucifer/Chess-In-C
  * ELKS port by Rafael Diniz */
 
-#include <stdarg.h>
-#include "cprintf.h"
+#include <stdio.h>
+#define cprintf printf
 
 extern int write(int, char *, int);
 extern int read(int, void *, int count);
@@ -413,13 +413,13 @@ void pawnb( int r1 , int c1 ) // paido black
 void player1()
 {
     int p1 , p2 , c1 , r1 , c2 , r2;
-	int tmp;
+	unsigned char tmp;
 
     cprintf( "\nPLAYER 1 - Big Case\n" );
 again1:
     cprintf( "\nEnter Position of Element to change ( RC ): " );
 	/* our scanf wrapper... scanf("%d", &p1) */
-    read(0, &tmp, 1);
+	read(0, &tmp, 1);
 	p1 = (tmp - 48) * 10;
 	read(0, &tmp, 1);
 	p1 += (tmp - 48);

--- a/examples/test.c
+++ b/examples/test.c
@@ -1,6 +1,8 @@
 
 #include <stdarg.h>
 #include "cprintf.h"
+#include <stdio.h>
+#include <stdlib.h>
 
 extern int write(int, char *, int);
 extern int read(int, void *, int count);
@@ -9,6 +11,7 @@ extern void exit(int);
 int main()
 {
 	cprintf("Hello World %c %s %d!\n", '1', "2", 3);
+	printf("Hello World %c %s %d!\n", '1', "2", 3);
 
 	exit(0);
 }

--- a/libc/syscall2.asm
+++ b/libc/syscall2.asm
@@ -29,19 +29,14 @@ _unlink:
         mov     ax, 10
         jmp     callsys
 
-        global _execve
-_execve:
+        global __execve
+__execve:
         mov     ax, 11
         jmp     callsys
 
         global _chdir
 _chdir:
         mov     ax, 12
-        jmp     callsys
-
-        global _time
-_time:
-        mov     ax, 13
         jmp     callsys
 
         global _mknod
@@ -59,8 +54,8 @@ _chown:
         mov     ax, 16
         jmp     callsys
 
-        global _brk
-_brk:
+        global __brk
+__brk:
         mov     ax, 17
         jmp     callsys
 
@@ -69,13 +64,13 @@ _stat:
         mov     ax, 18
         jmp     callsys
 
-        global _lseek
-_lseek:
+        global __lseek
+__lseek:
         mov     ax, 19
         jmp     callsys
 
-        global _getpid
-_getpid:
+        global __getpid
+__getpid:
         mov     ax, 20
         jmp     callsys
 
@@ -94,8 +89,8 @@ _setuid:
         mov     ax, 23
         jmp     callsys
 
-        global _getuid
-_getuid:
+        global __getuid
+__getuid:
         mov     ax, 24
         jmp     callsys
 
@@ -164,8 +159,8 @@ _getgid:
         mov     ax, 47
         jmp     callsys
 
-        global _signal
-_signal:
+        global __signal
+__signal:
         mov     ax, 48
         jmp     callsys
 
@@ -219,8 +214,8 @@ _select:
         mov     ax, 63
         jmp     callsys
 
-        global _readdir
-_readdir:
+        global __readdir
+__readdir:
         mov     ax, 64
         jmp     callsys
 
@@ -234,8 +229,8 @@ _setsid:
         mov     ax, 68
         jmp     callsys
 
-        global _sbrk
-_sbrk:
+        global __sbrk
+__sbrk:
         mov     ax, 69
         jmp     callsys
 
@@ -294,12 +289,12 @@ _getsocknam:
         mov     ax, 205
         jmp     callsys
 
-        global _fmemalloc
-_fmemalloc:
+        global __fmemalloc
+__fmemalloc:
         mov     ax, 206
         jmp     callsys
 
-        global _fmemfree
-_fmemfree:
+        global __fmemfree
+__fmemfree:
         mov     ax, 207
         jmp     callsys

--- a/libc/syscall2.s
+++ b/libc/syscall2.s
@@ -29,19 +29,14 @@ _unlink:
         mov     ax,#10
         jmp     near callsys
 
-        .global _execve
-_execve:
+        .global __execve
+__execve:
         mov     ax,#11
         jmp     near callsys
 
         .global _chdir
 _chdir:
         mov     ax,#12
-        jmp     near callsys
-
-        .global _time
-_time:
-        mov     ax,#13
         jmp     near callsys
 
         .global _mknod
@@ -59,8 +54,8 @@ _chown:
         mov     ax,#16
         jmp     near callsys
 
-        .global _brk
-_brk:
+        .global __brk
+__brk:
         mov     ax,#17
         jmp     near callsys
 
@@ -69,13 +64,13 @@ _stat:
         mov     ax,#18
         jmp     near callsys
 
-        .global _lseek
-_lseek:
+        .global __lseek
+__lseek:
         mov     ax,#19
         jmp     near callsys
 
-        .global _getpid
-_getpid:
+        .global __getpid
+__getpid:
         mov     ax,#20
         jmp     near callsys
 
@@ -94,8 +89,8 @@ _setuid:
         mov     ax,#23
         jmp     near callsys
 
-        .global _getuid
-_getuid:
+        .global __getuid
+__getuid:
         mov     ax,#24
         jmp     near callsys
 
@@ -159,13 +154,13 @@ _setgid:
         mov     ax,#46
         jmp     near callsys
 
-        .global _getgid
-_getgid:
+        .global __getgid
+__getgid:
         mov     ax,#47
         jmp     near callsys
 
-        .global _signal
-_signal:
+        .global __signal
+__signal:
         mov     ax,#48
         jmp     near callsys
 
@@ -219,8 +214,8 @@ _select:
         mov     ax,#63
         jmp     near callsys
 
-        .global _readdir
-_readdir:
+        .global __readdir
+__readdir:
         mov     ax,#64
         jmp     near callsys
 
@@ -234,8 +229,8 @@ _setsid:
         mov     ax,#68
         jmp     near callsys
 
-        .global _sbrk
-_sbrk:
+        .global __sbrk
+__sbrk:
         mov     ax,#69
         jmp     near callsys
 
@@ -294,12 +289,12 @@ _getsocknam:
         mov     ax,#205
         jmp     near callsys
 
-        .global _fmemalloc
-_fmemalloc:
+        .global __fmemalloc
+__fmemalloc:
         mov     ax,#206
         jmp     near callsys
 
-        .global _fmemfree
-_fmemfree:
+        .global __fmemfree
+__fmemfree:
         mov     ax,#207
         jmp     near callsys


### PR DESCRIPTION
The following enhancements and fixes were made in order to get the toolchain to accept compiling and assembling the ELKS C library:

- Lengthen AS86's input max line length from 256 to 512. With the -g option default on, the C line length displayed even as a comment exceeded the AS86 input buffer and AS86 got confused. Here's the post-processed line in libc/stdio/vfprintf.c that was longer than 384 characters:
```
    ; Line  250,             v = lval? (ap += ((sizeof( unsigned long)+sizeof(int)-1)&~(sizeof(int)-1)),                 (*( unsigned long *)(ap-((sizeof( unsigned long)+sizeof(int)-1)&~(sizeof(int)-1)))))  : (unsigned long)(ap += ((sizeof( unsigned int)+sizeof(int)-1)&~(sizeof(int)-1)),                 (*( unsigned int *)(ap-((sizeof( unsigned int)+sizeof(int)-1)&~(sizeof(int)-1))))) ;
```
- Fixed CPP86's processing of the ellipsis operator. This is used in a couple of places for optional debug output. Looks like the original CPP86 processing was added but never tested (and didn't work). While 'varargs' macro definitions are now supported by CPP86, they can't yet expand to anything and must remain blank. This will be fixed with a later addition of \_\_VA\_ARGS\_\_ processing. An example:
```
#define debug(...)     /* blank definitions only */
```
- Fix CPP86 bug where -Ddef didn't exactly match an internal preexisting matching instance '\#define def 1', which matched except for a trailing blank which CPP86 seems to want to add onto macro expansions (likely for whitespace separation of output tokens). The earlier code resulted in incorrect "\#define redefined macro" messages.
- Updated syscall2.{s,asm} code for system calls that have C wrappers. Note that all of libc/\*.c, libc/*.asm, libc/\*.s will no longer be maintained here, as it's being added to the C library on ELKS there the main libc86.a is being built.
- Replaced cprintf with printf in examples/test.c and chess.c in order to test C library. (It works!)
- Fixed bug in chess.c where 'int tmp; read(0, &tmp, 1);' was being used to read a single char into an int location. This resulted in the uninitialized garbage in the upper byte of tmp being used incorrectly.
- Updated examples/Makefile to use the C86 library now located at elks/libc/libc86.a
