### PR TITLE
Modify disasm86 to display better AS86 style output

### DIFF
--- a/disasm/dishand.c
+++ b/disasm/dishand.c
@@ -82,8 +82,8 @@ badseq(j,k)                   /* Invalid-sequence routine   */
    register int j, k;
 
 {
-   printf("\t.byte\t$%02.2x\t\t| invalid code sequence\n",j);
-   printf("\t.byte\t$%02.2x\n",k);
+   printf("\t.byte\t0x%02.2x\t\t| invalid code sequence\n",j);
+   printf("\t.byte\t0x%02.2x\n",k);
 }
 
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -107,7 +107,7 @@ dfhand(j)
 
    segflg = 0;
 
-   printf("\t.byte\t$%02.2x",j);
+   printf("\t.byte\t0x%02.2x",j);
 
    if (optab[j].min || optab[j].max)
       putchar('\n');
@@ -181,7 +181,7 @@ aohand(j)
 	 if( k < 16 )
             printf("%s\tal,*%d\n",optab[j].text,k);
 	 else
-            printf("%s\tal,*$%02.2x\n",optab[j].text,k);
+            printf("%s\tal,*0x%02.2x\n",optab[j].text,k);
          break;
       case 5 :
          FETCH(m);
@@ -192,9 +192,9 @@ aohand(j)
          else
 	    {
 	    if( k < 100 || k > 65436U )
-	       printf("%s\tax, %d\n",optab[j].text, (short)k);
+	       printf("%s\tax,#%d\n",optab[j].text, (short)k);
 	    else
-	       printf("%s\tax,#$%04x\n",optab[j].text,k);
+	       printf("%s\tax,#0x%04x\n",optab[j].text,k);
 	    }
          break;
       default :
@@ -362,7 +362,7 @@ imhand(j)
       case 2 :
          if (mod == 1)
 	 {
-            strcat(a,"word ");
+            strcat(a,"");               // NOTE was "*" for byte
             sprintf(b,"%d(", (short)offset);
 	 }
          else
@@ -371,7 +371,7 @@ imhand(j)
 	    if( offset < 100 || offset > 65436U )
                sprintf(b,"%d(", (short)offset);
 	    else
-               sprintf(b,"$%04x(",offset);
+               sprintf(b,"0x%04x(",offset);
 	 }
          strcat(a,b);
          strcat(a,REGS1[rm]);
@@ -389,11 +389,11 @@ imhand(j)
       if( immed < 100 || immed > 65436U )
          sprintf(b,"%d", (short)immed);
       else
-         sprintf(b,"$%04x",immed);
+         sprintf(b,"0x%04x",immed);
    }
    else
    {
-      strcat(a,"*");
+      strcat(a,"#");                    // NOTE was "*" for byte
       sprintf(b,"%d",immed);
    }
    strcat(a,b);
@@ -544,12 +544,12 @@ cihand(j)
    FETCH(m);
    FETCH(n);
 
-   printf("#$%04.4x,",((n << 8) | m));
+   printf("#0x%04.4x,",((n << 8) | m));
 
    FETCH(m);
    FETCH(n);
 
-   printf("#$%04.4x\n",((n << 8) | m));
+   printf("#0x%04.4x\n",((n << 8) | m));
 
    objout();
 
@@ -583,13 +583,13 @@ mihand(j)
       FETCH(n);
       k = ((n << 8) | m);
       if (lookext((long)(k),(PC - 1),b))
-         printf(" %s\n",b);
+         printf("#%s\n",b);
       else
          {
          if( k < 100 || k > 65436U )
-            printf(" %d\n",(short)k);
+            printf("#%d\n",(short)k);
 	 else
-            printf(" 0x%04X\n",k);
+            printf("#0x%04X\n",k);
          }
       }
    else
@@ -670,13 +670,13 @@ tqhand(j)
       FETCH(n);
       k = ((n << 8) | m);
       if (lookext((long)(k),(PC - 1),b))
-         printf(" %s\n",b);
+         printf("#%s\n",b);
       else
          {
          if( k < 100 || k > 65436U )
-            printf(" %d\n",(short)k);
+            printf("#%d\n",(short)k);
 	 else
-            printf(" 0x%04X\n",k);
+            printf("#0x%04X\n",k);
          }
       }
    else
@@ -771,19 +771,19 @@ mmhand(j)
       FETCH(k);
       k = (k << 8) | j;
       if (lookext((long)(k),(PC - 1),b))
-         printf(" %s\n",b);
+         printf("#%s\n",b);
       else
          {
          if( k < 100 || k > 65436U )
-            printf(" %d\n",(short)k);
+            printf("#%d\n",(short)k);
 	 else
-            printf(" 0x%04X\n",k);
+            printf("#0x%04X\n",k);
          }
       }
    else
       {
       FETCH(k);
-      printf(" %d\n",k);
+      printf("*%d\n",k);
       }
 
    objout();
@@ -997,9 +997,9 @@ mahand(j)
          FETCH(k);
          k = (k << 8) | j;
          if (lookext((long)(k),(PC - 1),b))
-            printf(", %s\n",b);
+            printf(",#%s\n",b);
          else
-            printf(", 0x%04X\n",k);
+            printf(",#0x%04X\n",k);
          }
       else
          {

--- a/disasm/dismain.c
+++ b/disasm/dismain.c
@@ -221,7 +221,8 @@ register int type;
    register int k;
    static char b[48], c[32];
 
-   if (symptr < 0) {
+   if (symptr < 0)
+      {
       if ((type == N_TEXT)
        || ((type == N_DATA) && ( ! objptr ) && ( ! zcount )))
          {
@@ -231,9 +232,9 @@ register int type;
             sprintf(b,"D%05.5lx:",PC);
          return (b);
          }
-   } else {
+      else
          return (NULL);
-   }
+      }
 
    for (k = 0; k <= symptr; ++k)
       if ((symtab[k].n_value == PC)
@@ -277,7 +278,7 @@ prolog()
           && ((symtab[j].n_sclass & N_SECT) < N_COMM))
             {
             char *c = getnam(j);
-            printf("\tglobal\t%s",c);
+            printf("\t.global\t%s",c);
             if (++flag == 1)
                {
                putchar('\t');
@@ -312,7 +313,7 @@ prolog()
          {
          char *c = getnam(relo[j].r_symndx);
          ++flag;
-         printf("\tglobal\t%s",c);
+         printf("\t.global\t%s",c);
          putchar('\t');
          if (strlen(c) < 8)
             putchar('\t');

--- a/disasm/distabs.c
+++ b/disasm/distabs.c
@@ -519,7 +519,7 @@ lookup(addr,type,kind,ext)
       return (getnam(best.i));
 
    if (kind == LOOK_ABS)
-      sprintf(b,"$%04lx",addr);
+      sprintf(b,"[0x%04lx]",addr);
    else
       {
       long x = addr - (PC - kind);
@@ -630,7 +630,7 @@ mtrans(c,m,type)
          case 1 :
          case 2 :
             if (mod == 1)
-               strcat(a," WORD ");
+               strcat(a,"");            // NOTE was "*" for byte
             else
                strcat(a,"#");
             sprintf(b,"%d[", (short)offset);
@@ -666,7 +666,7 @@ mtrans(c,m,type)
          case 1 :
          case 2 :
             if (mod == 1)
-               strcpy(a,"word ");
+               strcpy(a,"");            // NOTE was "*" for byte
             else
                strcpy(a,"#");
             sprintf(b,"%d[", (short)offset);


### PR DESCRIPTION
Changes and fixes some routines previously modified for NASM to display AS86 output.

Changes more previous PC/IX output to AS86 output.

Fixes error in previous commit that broke display of text labels.