### PR TITLE
[disasm] Display referenced .data or .bss symbol for separate I&D executables

### DIFF
--- a/disasm/disfp.c
+++ b/disasm/disfp.c
@@ -1,5 +1,4 @@
-static char *sccsid =
-   "@(#) disfp.c, Ver. 2.1 created 00:00:00 87/09/01";
+//static char *sccsid = "@(#) disfp.c, Ver. 2.1 created 00:00:00 87/09/01";
 
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   *                                                         *

--- a/disasm/dishand.c
+++ b/disasm/dishand.c
@@ -1,5 +1,4 @@
-static char *sccsid =
-   "@(#) dishand.c, Ver. 2.1 created 00:00:00 87/09/01";
+//static char *sccsid = "@(#) dishand.c, Ver. 2.1 created 00:00:00 87/09/01";
 
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   *                                                         *

--- a/disasm/dishand.c
+++ b/disasm/dishand.c
@@ -588,14 +588,14 @@ mihand(j)
          {
          if( k < 100 || k > 65436U )
             printf("#%d\n",(short)k);
-	 else
+         else
             printf("#0x%04X\n",k);
          }
       }
    else
       {
       FETCH(m);
-      printf("*%d\n",m);
+      printf("#%d\n",m);        // NOTE: was "*"
       }
 
    objout();
@@ -675,7 +675,7 @@ tqhand(j)
          {
          if( k < 100 || k > 65436U )
             printf("#%d\n",(short)k);
-	 else
+         else
             printf("#0x%04X\n",k);
          }
       }
@@ -683,7 +683,7 @@ tqhand(j)
       {
       if (m & 80)
          m |= -0xFF;
-      printf("*%d\n",m);
+      printf("#%d\n",m);        // NOTE: was "*"
       }
 
    objout();
@@ -776,14 +776,14 @@ mmhand(j)
          {
          if( k < 100 || k > 65436U )
             printf("#%d\n",(short)k);
-	 else
+         else
             printf("#0x%04X\n",k);
          }
       }
    else
       {
       FETCH(k);
-      printf("*%d\n",k);
+      printf("#%d\n",k);        // NOTE: was "*"
       }
 
    objout();
@@ -831,7 +831,7 @@ srhand(j)
    if (j & 2)
       printf(",cl\n");
    else
-      printf(",*1\n");
+      printf(",#1\n");          // NOTE: was "*"
 
    objout();
 

--- a/disasm/dismain.c
+++ b/disasm/dismain.c
@@ -240,9 +240,9 @@ register int type;
       if ((symtab[k].n_value == PC)
        && ((symtab[k].n_sclass & N_SECT) == type))
          {
-         sprintf(b,"%s:\n",getnam(k));
-         if (objflg && (type != N_TEXT))
-            sprintf(c,"| %05.5lx\n",PC);
+         sprintf(b,"%s:    ",getnam(k));
+         /*if (objflg && (type != N_TEXT))*/    /* ghaerr: always display loc */
+            sprintf(c,"\t\t\t| loc %05.5lx\n",PC);
          strcat(b,c);
          return (b);
          }

--- a/disasm/dismain.c
+++ b/disasm/dismain.c
@@ -1,4 +1,4 @@
-static char *sccsid =  "@(#) dismain.c, Ver. 2.1 created 00:00:00 87/09/01";
+//static char *sccsid =  "@(#) dismain.c, Ver. 2.1 created 00:00:00 87/09/01";
 
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   *                                                         *

--- a/disasm/disrel.c
+++ b/disasm/disrel.c
@@ -1,15 +1,9 @@
-static char *copyright =
-   "@(#) Copyright (C) 1987 G. M. Harding, all rights reserved";
+static char *copyright = "@(#) Copyright (C) 1987 G. M. Harding, all rights reserved";
 
-#if 0
-char *release =
-   "released with Dev86 for Linux, based on minix 2.1";
-#else
-static char *sccsid =
-   "@(#) disrel.c, Ver. 2.1 created 00:00:00 87/09/01";
+//static char *sccsid = "@(#) disrel.c, Ver. 2.1 created 00:00:00 87/09/01";
 
+//char *release = "released with Dev86 for Linux, based on minix 2.1";
 char *release = "release 2.2pre (ELKS)";    /* was 2.1 (MINIX) */
-#endif
 
  /*
  **

--- a/disasm/distabs.c
+++ b/disasm/distabs.c
@@ -436,6 +436,29 @@ lookext(off,loc,buf)
 
 }/* * * * * * * * * *  END OF  lookext()  * * * * * * * * * */
 
+
+static char *
+getdatalab(addr)
+unsigned long addr;
+{/* * * * * * * * * *  START OF getdatalab()  * * * * * * * * * */
+
+   register int k;
+
+   if (symptr < 0)
+      return (NULL);
+
+   for (k = 0; k <= symptr; ++k)
+      if ((symtab[k].n_value == addr)
+       && (((symtab[k].n_sclass & N_SECT) == N_DATA)
+        || ((symtab[k].n_sclass & N_SECT) == N_BSS)))
+         {
+         return getnam(k);
+         }
+
+   return (NULL);
+
+}/* * * * * * * * * * * END OF getdatalab() * * * * * * * * * * */
+
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   *                                                         *
   * This  function  finds an entry in the  symbol  table by *
@@ -519,7 +542,12 @@ lookup(addr,type,kind,ext)
       return (getnam(best.i));
 
    if (kind == LOOK_ABS)
-      sprintf(b,"[0x%04lx]",addr);
+      {
+      char *c = getdatalab(addr);
+      if (c)
+         sprintf(b,"[%s]",c);
+      else sprintf(b,"[0x%04lx]",addr);
+      }
    else
       {
       long x = addr - (PC - kind);

--- a/disasm/distabs.c
+++ b/disasm/distabs.c
@@ -1,5 +1,4 @@
-static char *sccsid =
-   "@(#) distabs.c, Ver. 2.1 created 00:00:00 87/09/01";
+//static char *sccsid = "@(#) distabs.c, Ver. 2.1 created 00:00:00 87/09/01";
 
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   *                                                         *

--- a/disasm/distabs.c
+++ b/disasm/distabs.c
@@ -437,10 +437,11 @@ lookext(off,loc,buf)
 }/* * * * * * * * * *  END OF  lookext()  * * * * * * * * * */
 
 
+/* find data symbol name from .data or .bss section */
 static char *
 getdatalab(addr)
 unsigned long addr;
-{/* * * * * * * * * *  START OF getdatalab()  * * * * * * * * * */
+{
 
    register int k;
 
@@ -457,7 +458,7 @@ unsigned long addr;
 
    return (NULL);
 
-}/* * * * * * * * * * * END OF getdatalab() * * * * * * * * * * */
+}
 
  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   *                                                         *
@@ -502,6 +503,7 @@ lookup(addr,type,kind,ext)
 {/* * * * * * * * * *  START OF lookup()  * * * * * * * * * */
 
    register int j, k;
+   char *c;
    static char b[80];
 
    struct
@@ -543,10 +545,11 @@ lookup(addr,type,kind,ext)
 
    if (kind == LOOK_ABS)
       {
-      char *c = getdatalab(addr);
+      c = getdatalab(addr);     /* ghaerr: display data symbol when separate I&D */
       if (c)
          sprintf(b,"[%s]",c);
-      else sprintf(b,"[0x%04lx]",addr);
+      else
+         sprintf(b,"[0x%04lx]",addr);
       }
    else
       {


### PR DESCRIPTION
Adds more changes from PC/IX to AS86 output.

Removes sccsid[] strings from executable.