### PR TITLE
Remove ld/writebin.c and writeemu.c for space, use -DREL_NATIVE (not set)

### DIFF
--- a/examples/Makefile.elks
+++ b/examples/Makefile.elks
@@ -42,11 +42,11 @@ all: chess test
 test: test.o cprintf.o
 	$(LD) $(LDFLAGS) test.o cprintf.o -lc86 -o test
 
-test.o: test.asm
-	$(AS) $(ASFLAGS)  test.asm -o test.o
+test.o: test.as
+	$(AS) $(ASFLAGS)  test.as -o test.o
 
-test.asm: test.i
-	$(CC) $(CFLAGS) test.i test.asm
+test.as: test.i
+	$(CC) $(CFLAGS) test.i test.as
 
 test.i: test.c
 	$(CPP) $(CPPFLAGS) test.c -o test.i
@@ -54,26 +54,26 @@ test.i: test.c
 chess: chess.o
 	$(LD) $(LDFLAGS) chess.o -lc86 -o chess
 
-chess.o: chess.asm
-	$(AS) $(ASFLAGS)  chess.asm -o chess.o
+chess.o: chess.as
+	$(AS) $(ASFLAGS)  chess.as -o chess.o
 
-chess.asm: chess.i
-	$(CC) $(CFLAGS) chess.i chess.asm
+chess.as: chess.i
+	$(CC) $(CFLAGS) chess.i chess.as
 
 chess.i: chess.c
 	$(CPP) $(CPPFLAGS) chess.c -o chess.i
 
-cprintf.o: cprintf.asm
-	$(AS) $(ASFLAGS)  cprintf.asm -o cprintf.o
+cprintf.o: cprintf.as
+	$(AS) $(ASFLAGS)  cprintf.as -o cprintf.o
 
-cprintf.asm: cprintf.i
-	$(CC) $(CFLAGS) cprintf.i cprintf.asm
+cprintf.as: cprintf.i
+	$(CC) $(CFLAGS) cprintf.i cprintf.as
 
 cprintf.i: cprintf.c
 	$(CPP) $(CPPFLAGS) cprintf.c -o cprintf.i
 
 
 clean:
-	rm -f *.o *.i *.asm  test chess
+	rm -f *.o *.i *.as  test chess
 
 # end

--- a/ld/Makefile
+++ b/ld/Makefile
@@ -25,13 +25,14 @@ OBJS = $(SRCS:.c=.o)
 #
 # An alternative file for a non-standard a.out.h (eg i386 linux on an Alpha)
 # NATIVE=-DA_OUT_INCL='"a_out_local.h"' 
-DEFINES += -DREL_OUTPUT
+#DEFINES += -DREL_OUTPUT -DREL_NATIVE
+#SRCS += writebin.c writeemu.c
 
 BINDIR=../host-bin
 LOCALFLAGS = -Wno-missing-field-initializers -Wno-sign-compare
 PROG = $(BINDIR)/ld86 $(BINDIR)/objdump86
 SRCS = dumps.c io.c ld.c readobj.c table.c typeconv.c linksyms.c mkar.c \
-      writex86.c writebin.c writeemu.c
+      writex86.c
 
 all: $(PROG)
 

--- a/ld/Makefile.elks
+++ b/ld/Makefile.elks
@@ -44,13 +44,14 @@ OBJS = $(SRCS:.c=.obj)
 #
 # An alternative file for a non-standard a.out.h (eg i386 linux on an Alpha)
 # NATIVE=-DA_OUT_INCL='"a_out_local.h"' 
-DEFINES += -DREL_OUTPUT
+#DEFINES += -DREL_OUTPUT -DREL_NATIVE
+#SRCS += writebin.c writeemu.c
 
 BINDIR = ../elks-bin
 LOCALFLAGS =
 PROG = $(BINDIR)/ld86 $(BINDIR)/objdump86
 SRCS = dumps.c io.c ld.c readobj.c table.c typeconv.c linksyms.c mkar.c \
-      writex86.c writebin.c writeemu.c
+      writex86.c
 
 all: $(PROG)
 

--- a/ld/ld.c
+++ b/ld/ld.c
@@ -123,7 +123,9 @@ char **argv;
 	    case 'm':		/* print modules linked */
 	    case 's':		/* strip symbols */
 	    case 'z':		/* unmapped zero page */
+#ifdef REL_NATIVE
 	    case 'N':		/* Native format a.out */
+#endif
 	    case 'd':		/* Make a headerless outfile */
 #ifndef MSDOS
 	    case 'c':		/* Write header in CP/M-86 format */
@@ -270,15 +272,19 @@ char **argv;
     if (outfilename == NUL_PTR)
 	outfilename = "a.out";
 #ifndef MSDOS
+#ifdef REL_NATIVE
     if( flag['N'] )
        writebin(outfilename, flag['i'], flag['3'], flag['s'],
 	     flag['z'] & flag['3']);
     else
 #endif
+#endif
+#ifdef REL_NATIVE
     if( flag['B'] )
        write_dosemu(outfilename, flag['i'], flag['3'], flag['s'],
 	  flag['z'] & flag['3']);
     else
+#endif
        write_elks(outfilename, flag['i'], flag['3'], flag['s'],
 	     flag['z'], flag['y']);
     if (flag['m'])

--- a/ld/linksyms.c
+++ b/ld/linksyms.c
@@ -23,6 +23,7 @@ bool_pt argreloc_output;
     struct modstruct *modptr;
     struct symstruct *symptr;
 
+    (void)argreloc_output;
 #ifdef REL_OUTPUT
     reloc_output = argreloc_output;
     if (argreloc_output)

--- a/ld/writebin.c
+++ b/ld/writebin.c
@@ -998,7 +998,11 @@ PRIVATE void writeheader()
 	/* XXX - works for 386BSD which doesn't define its own machtype :-( */
 #endif
 #else
-    header.a_cpu = (bits32 || reloc_output) ? A_I80386 : A_I8086;
+    header.a_cpu = (bits32
+#ifdef REL_OUTPUT
+    || reloc_output
+#endif
+                    ) ? A_I80386 : A_I8086;
 #endif
 #else
     header.a_cpu = bits32 ? A_I80386 : A_I8086;


### PR DESCRIPTION
Removes some extra LD86 code found while chasing down the fact that 8086-toolchain doesn't work on FAT filesystems. 
Setting REL_OUTPUT (default off) would allow for LD86 to produce and combine .o files, and REL_NATIVE would be used for producing native a.out files (not ELKS compatible). So both are unused and turned off by default.

Discussed in https://github.com/ghaerr/elks/issues/2159#issuecomment-2566011921.

Also changes intermediate AS86 output extension from .asm to .as, so as to not unintentionally overwrite NASM or AS86 handwritten .asm files.