### PR TITLE
Update build for watcom include files, add as86 temp pass #'s

### DIFF
--- a/as/Makefile.elks
+++ b/as/Makefile.elks
@@ -17,7 +17,7 @@ CLBASE += -fno-stack-check -fnostdlib
 CLBASE += -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -Wc,-wcd=303
 WARNINGS = -Wall -Wextra
 INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
-INCLUDES += -I$(WATCOM)/h
+INCLUDES += -I$(TOPDIR)/libc/include/watcom
 DEFINES = -D__ELKS__
 CFLAGS = -Os $(CLBASE) $(WARNINGS) $(INCLUDES) $(DEFINES) $(LOCALFLAGS)
 LDBASE = -bos2 -s

--- a/as/as.c
+++ b/as/as.c
@@ -5,6 +5,7 @@
   in any order (but no repeated file options)
 */
 
+#include <stdio.h>
 #include "syshead.h"
 #include "const.h"
 #include "type.h"
@@ -44,6 +45,7 @@ char **argv;
     init_heap();
     initp1();
     initp1p2();
+    printf("Init\n");
     inst_keywords();
     initbin();
     initobj();
@@ -55,6 +57,7 @@ char **argv;
     process_args(argc, argv);
     initscan();
     line_zero();
+    printf("Pass 1\n");
 
     assemble();			/* doesn't return, maybe use setjmp */
 

--- a/as/readsrc.c
+++ b/as/readsrc.c
@@ -1,5 +1,6 @@
 /* readsrc.c - read source files for assembler */
 
+#include <stdio.h>
 #include "syshead.h"
 #include "const.h"
 #include "type.h"
@@ -248,6 +249,7 @@ PUBLIC void pproceof()
     else if (pass!=last_pass)
     {
 	pass++;
+	printf("Pass %d\n", pass+1);
 	if( last_pass>1 && last_pass<30 && dirty_pass && pass==last_pass )
 	   last_pass++;
 

--- a/compiler/Makefile.elks
+++ b/compiler/Makefile.elks
@@ -17,7 +17,7 @@ CLBASE += -fno-stack-check -fnostdlib
 CLBASE += -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -Wc,-wcd=303
 WARNINGS = -Wall -Wextra
 INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
-INCLUDES += -I$(WATCOM)/h
+INCLUDES += -I$(TOPDIR)/libc/include/watcom
 DEFINES = -D__ELKS__
 CFLAGS = -Os $(CLBASE) $(WARNINGS) $(INCLUDES) $(DEFINES) $(LOCALFLAGS)
 LDBASE = -bos2 -s

--- a/compiler/mem.c
+++ b/compiler/mem.c
@@ -55,14 +55,17 @@ void *realloc(void *ptr, size_t size)
 
 #if LATER
     /* we can't yet get size from fmemalloc'd block */
-    osize = malloc_usable_size(ptr);
-    if (size <= osize)
+    osize = __amalloc_usable_size(ptr);
+    __dprintf("old %u new %u\n", osize, size);
+    if (size < osize || osize == 0)
         osize = size;           /* copy less bytes in memcpy below */
 #endif
 
     new = malloc(size);
-    if (new == 0)
+    if (new == 0) {
+        __dprintf("realloc: Out of memory\n");
         return 0;
+    }
     memcpy(new, ptr, osize);    /* FIXME copies too much but can't get real osize */
     free(ptr);
     return new;

--- a/cpp/Makefile.elks
+++ b/cpp/Makefile.elks
@@ -17,7 +17,7 @@ CLBASE += -fno-stack-check -fnostdlib
 CLBASE += -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -Wc,-wcd=303
 WARNINGS = -Wall -Wextra
 INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
-INCLUDES += -I$(WATCOM)/h
+INCLUDES += -I$(TOPDIR)/libc/include/watcom
 DEFINES = -D__ELKS__
 CFLAGS = -Os $(CLBASE) $(WARNINGS) $(INCLUDES) $(DEFINES) $(LOCALFLAGS)
 LDBASE = -bos2 -s

--- a/cpp/cc.h
+++ b/cpp/cc.h
@@ -28,7 +28,7 @@ struct token_trans { char * name; int token; };
 struct token_trans * is_ctok P((register const char *str, register size_t len));
 struct token_trans * is_ckey P((register const char *str, register size_t len));
 
-#define WORDSIZE	200         /* ghaerr: fixes crash, was 128 */
+#define WORDSIZE	128
 #define TK_WSPACE	256
 #define TK_WORD 	257
 #define TK_NUM  	258
@@ -106,7 +106,6 @@ extern void * read_entry P((int,char*));
 
 struct define_item
 {
-   struct define_arg * next;
    char * name;
    int arg_count;	/* -1 = none; >=0 = brackets with N args */
    int in_use;		/* Skip this one for looking up #defines */

--- a/cpp/cpp.c
+++ b/cpp/cpp.c
@@ -598,7 +598,6 @@ static int realchget(void)
       if( def_ptr )
       {
 	 ch = *def_ptr++; if(ch) return (unsigned char)ch;
-	 if( def_start ) free(def_start);
 	 if( def_ref ) def_ref->in_use = 0;
 
 	 def_count--;
@@ -871,7 +870,6 @@ static void do_proc_define(void)
       if(ptr==0) cfatal("Preprocessor out of memory");
       ptr->name = set_entry(0, name, ptr);
       ptr->in_use = 0;
-      ptr->next = 0;
 
       if (old_value) {
 	 if (strcmp(old_value->value, ptr->value) != 0)

--- a/cpp/main.c
+++ b/cpp/main.c
@@ -2,7 +2,9 @@
 #include <stdio.h>
 #if __STDC__
 #include <stdlib.h>
+#ifndef __ELKS__
 #include <locale.h>
+#endif
 #else
 #include <malloc.h>
 #endif
@@ -213,7 +215,6 @@ char * name;
    strcat(ptr->value, " ");     /* ghaerr: match #define definitions */
    ptr->arg_count = -1;
    ptr->in_use = 0;
-   ptr->next = 0;
 }
 
 FILE *

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,7 +17,8 @@ DEFINES=
 CPPFLAGS=-0 $(INCLUDES) $(DEFINES)
 CFLAGS=-g -O -bas86 -warn=4 -lang=c99
 CFLAGS+=-align=yes -separate=yes -stackopt=minimum -peep=all -stackcheck=no
-ASFLAGS=-0 -O -j -w-
+#ASFLAGS=-0 -j -O -w-
+ASFLAGS=-0 -j
 LDFLAGS=-0 -i -L$(C86LIB)
 NASMFLAGS=-f as86
 

--- a/examples/Makefile.elks
+++ b/examples/Makefile.elks
@@ -32,7 +32,8 @@ DEFINES=
 
 CPPFLAGS=-0 $(INCLUDES) $(DEFINES)
 CFLAGS=-g -v -O -bas86 -separate=yes -warn=4 -lang=c99 -align=yes -stackopt=minimum -peep=all -stackcheck=no
-ASFLAGS=-0 -O -j -w-
+#ASFLAGS=-0 -j -O -w-
+ASFLAGS=-0 -j
 LDFLAGS=-0 -i -L$(C86LIB)
 
 ##### End of standardized section #####
@@ -74,6 +75,6 @@ cprintf.i: cprintf.c
 
 
 clean:
-	rm -f *.o *.i *.as  test chess
+	rm -f *.i *.o *.as test chess
 
 # end

--- a/ld/Makefile.elks
+++ b/ld/Makefile.elks
@@ -17,7 +17,7 @@ CLBASE += -fno-stack-check -fnostdlib
 CLBASE += -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -Wc,-wcd=303
 WARNINGS = -Wall -Wextra
 INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
-INCLUDES += -I$(WATCOM)/h
+INCLUDES += -I$(TOPDIR)/libc/include/watcom
 DEFINES = -D__ELKS__
 CFLAGS = -Os $(CLBASE) $(WARNINGS) $(INCLUDES) $(DEFINES) $(LOCALFLAGS)
 LDBASE = -bos2 -s

--- a/nasm/Makefile.elks
+++ b/nasm/Makefile.elks
@@ -25,7 +25,7 @@ else
 	WATCOMC=${WATCOM}
 endif
 
-CC =  owcc -c -bnone -mcmodel=l -march=i86 -Os -std=c99 -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -fno-stack-check -fnostdlib -Wall -Wextra -Wc,-wcd=303 -I$(TOPDIRE)/libc/include -I$(TOPDIRE)/include -I$(TOPDIRE)/elks/include -I$(WATCOMC)/h -IH -D__UNIX__ -D__ELKS__ -DOF_ONLY -DOF_BIN -DOF_AS86 -DOF_DEFAULT=of_as86
+CC =  owcc -c -bnone -mcmodel=l -march=i86 -Os -std=c99 -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -fno-stack-check -fnostdlib -Wall -Wextra -Wc,-wcd=303 -I$(TOPDIRE)/libc/include -I$(TOPDIRE)/include -I$(TOPDIRE)/elks/include -I$(TOPDIRE)/libc/include/watcom -D__UNIX__ -D__ELKS__ -DOF_ONLY -DOF_BIN -DOF_AS86 -DOF_DEFAULT=of_as86
 #CC = ia16-elf-gcc -mcmodel=small -std=c11 -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -Wno-implicit-int -Wno-parentheses  -I/home/rafael2k/programs/devel/elks/libc/include -I/home/rafael2k/programs/devel/elks/elks/include -D__ELKS__
 LINK = owcc -bos2 -s -Wl,option -Wl,start=_start -Wl,option -Wl,dosseg -Wl,option -Wl,nodefaultlibs -Wl,option -Wl,stack=0x1000 -Wl,option -Wl,heapsize=256 -Wl,library -Wl,$(TOPDIRE)/libc/libc.lib
 

--- a/nasm32/Makefile.elks
+++ b/nasm32/Makefile.elks
@@ -25,7 +25,7 @@ else
 	WATCOMC=${WATCOM}
 endif
 
-CC =  owcc -c -bnone -mcmodel=l -march=i86 -Os -std=c99 -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -fno-stack-check -fnostdlib -Wall -Wextra -Wc,-wcd=303 -I$(TOPDIRE)/libc/include -I$(TOPDIRE)/include -I$(TOPDIRE)/elks/include -I$(WATCOMC)/h -IH -D__UNIX__ -D__ELKS__ -DOF_ONLY -DOF_OBJ -DOF_BIN -DOF_ELF -DOF_AOUT -DOF_AS86
+CC =  owcc -c -bnone -mcmodel=l -march=i86 -Os -std=c99 -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -fno-stack-check -fnostdlib -Wall -Wextra -Wc,-wcd=303 -I$(TOPDIRE)/libc/include -I$(TOPDIRE)/include -I$(TOPDIRE)/elks/include -I$(TOPDIRE)/libc/include/watcom -D__UNIX__ -D__ELKS__ -DOF_ONLY -DOF_OBJ -DOF_BIN -DOF_ELF -DOF_AOUT -DOF_AS86
 #CC = ia16-elf-gcc -mcmodel=small -std=c11 -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -Wno-implicit-int -Wno-parentheses  -I/home/rafael2k/programs/devel/elks/libc/include -I/home/rafael2k/programs/devel/elks/elks/include -D__ELKS__
 LINK = owcc -bos2 -s -Wl,option -Wl,start=_start -Wl,option -Wl,dosseg -Wl,option -Wl,nodefaultlibs -Wl,option -Wl,stack=0x1000 -Wl,option -Wl,heapsize=0x4000 -Wl,library -Wl,$(TOPDIRE)/libc/libc.lib
 


### PR DESCRIPTION
Removes AS86 "-O -w-" multipass optimization and warnings for speed on slower 8088 systems on example/ builds.

AS86 temporary displays "Init" when intializing keyword hash table and assembly pass numbers, for timing purposes.

Cleans up CPP source after some extensive debugging as to crashing/panicking ELKS, which finally showed that ELKS libc `ctime` and OWC `gettimeofday` with a NULL first parameter were the culprits.

Removes requirement for WATCOM header files, instead uses ELKS C library headers.
