### PR TITLE
Add $^ automatic variable to make86

### DIFF
--- a/examples/Makefile.elks
+++ b/examples/Makefile.elks
@@ -48,16 +48,16 @@ PROGS=chess test show_fonts vgatest
 all: $(PROGS)
 
 chess: chess.o
-	$(TIME) $(LD) $(LDFLAGS) -o $@ chess.o $(LDLIBS)
+	$(TIME) $(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 test: test.o cprintf.o
-	$(TIME) $(LD) $(LDFLAGS) -o $@ test.o cprintf.o $(LDLIBS)
+	$(TIME) $(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 show_fonts: show_fonts.o
-	$(TIME) $(LD) $(LDFLAGS) -o $@ show_fonts.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 vgatest: vgatest.o
-	$(LD) $(LDFLAGS) -o $@ vgatest.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:
 	rm -f *.i *.o *.as $(PROGS)

--- a/make/make.c
+++ b/make/make.c
@@ -206,6 +206,7 @@ static void make1(struct name *np, struct line *lp, struct depend *qdp)
             free((char *)dp);
         }
         setmacro("?", str1, 4);
+        setmacro("^", str1, 4);
         setmacro("@", np->n_name, 4);
         p = strrchr(np->n_name, '.');
         if (p) *p = 0;


### PR DESCRIPTION
Adds "$^" variable to make86, allowing for more standardized Makefiles. 

Updates examples/Makefile.elks to take advantage of the variable.