### PR TITLE
Add BIN= to examples/Makefiles for path

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -4,11 +4,12 @@ ifndef TOPDIR
 $(error ELKS TOPDIR is not defined)
 endif
 
-CPP=../host-bin/cpp86
-CC=../host-bin/c86
-AS=../host-bin/as86
-LD=../host-bin/ld86
-NASM=../host-bin/nasm86
+BIN=../host-bin/
+CPP=$(BIN)cpp86
+CC=$(BIN)c86
+AS=$(BIN)as86
+LD=$(BIN)ld86
+NASM=$(BIN)nasm86
 
 C86LIB=$(TOPDIR)/libc
 INCLUDES=-I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include -I$(C86LIB)/include/c86

--- a/examples/Makefile.elks
+++ b/examples/Makefile.elks
@@ -8,21 +8,23 @@
 
 INCLUDES=-I.
 C86LIB=.
+BIN=./
 
 # Uncomment the following lines to build on host using make86, then run:
 #   'make86 -f Makefile.elks TOPDIR=/Users/greg/net/elks-gh all'
 #INCLUDES=-I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include -I$(TOPDIR)/libc/include/c86
 #C86LIB=$(TOPDIR)/libc
+#BIN=
 
 DEFINES=
 #TIME=time
 
 ##### Standardized section of Makefile #####
 
-CPP=cpp86
-CC=c86
-AS=as86
-LD=ld86
+CPP=$(BIN)cpp86
+CC=$(BIN)c86
+AS=$(BIN)as86
+LD=$(BIN)ld86
 
 CPPFLAGS=-0 $(INCLUDES) $(DEFINES)
 CFLAGS=-g -O -bas86 -separate=yes -warn=4 -lang=c99 \


### PR DESCRIPTION
Changes allow for . to be removed from PATH on ELKS build, or for moving tools to different installed location easily.