### PR TITLE
Update examples/Makefile.elks for development disk on /usr

### DIFF
--- a/cpp/cc.h
+++ b/cpp/cc.h
@@ -18,6 +18,7 @@ extern char * c_fname;
 extern int    c_lineno;
 extern int    alltok;
 extern int    dialect;
+extern int    verbose;
 
 #define DI_KNR	1
 #define DI_ANSI	2

--- a/cpp/cpp.c
+++ b/cpp/cpp.c
@@ -609,8 +609,11 @@ static int realchget(void)
       }
 
       ch = getc(curfile);
+      if (ch == EOF && ferror(curfile))	/* NOTE: fgetc/fread read errors return EOF! */
+	  cerror("Cannot read include file");
       if( ch == EOF && fi_count != 0)
       {
+	 if (verbose) fprintf(stderr, "close %s\n", c_fname);
 	 fclose(curfile);
 	 fi_count--;
 	 curfile  = saved_files[fi_count];

--- a/cpp/main.c
+++ b/cpp/main.c
@@ -35,6 +35,7 @@ int last_line = -1;
 int debug_mode = 0;
 int p_flag = 0;
 int exit_code = 0;
+int verbose;
 
 char * outfile = 0;
 FILE * ofd = 0;
@@ -46,12 +47,10 @@ char ** argv;
 {
    int ar, i;
    char * p;
-static char Usage[] = "Usage: cpp -E -0 -Dxxx -Uxxx -Ixxx infile -o outfile";
+   static char Usage[] = "Usage: cpp [-0pdAKTV] -Dxxx -Uxxx -Ixxx infile -o outfile";
 
-#ifndef __ELKS__
-#ifdef LC_CTYPE
+#if defined(LC_CTYPE) && !defined(__ELKS__)
    setlocale(LC_CTYPE, "");
-#endif
 #endif
 
    alltok = 1;	/* Get all tokens from the cpp. */
@@ -59,6 +58,7 @@ static char Usage[] = "Usage: cpp -E -0 -Dxxx -Uxxx -Ixxx infile -o outfile";
    for(ar=1; ar<argc; ar++) if( argv[ar][0] == '-') switch(argv[ar][1])
    {
    case 'd': debug_mode++; break;
+   case 'V': verbose++; break;
    case 'T': alltok = 0; break;
    case 'A': dialect = DI_ANSI; break;
    case 'K': dialect = DI_KNR; break;
@@ -235,6 +235,7 @@ int checkrel;
       strcpy(p, fname);
 
       fd=fopen(buf, mode);
+      if (verbose) fprintf(stderr, "open \"%s\" = %d\n", buf, fd? fileno(fd): -1);
    }
    if (!fd) {
       for(i=0; i<MAXINCPATH; i++)
@@ -243,6 +244,7 @@ int checkrel;
 	   if (buf[strlen(buf)-1] != '/') strcat(buf, "/");
 	   strcat(buf, fname);
 	   fd=fopen(buf,  mode);
+	   if (verbose) fprintf(stderr, "open <%s> = %d\n", buf, fd? fileno(fd): -1);
 	   if( fd ) break;
 	 }
    }

--- a/cpp/mem.c
+++ b/cpp/mem.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define MALLOC_ARENA_SIZE   16000U  /* size of initial arena fmemalloc (max 65520)*/
+#define MALLOC_ARENA_SIZE   32000U  /* size of initial arena fmemalloc (max 65520)*/
 #define MALLOC_ARENA_THRESH 1024U   /* max size to allocate from arena-managed heap */
 
 unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,9 +46,9 @@ NASMFLAGS=-f as86
 PROGS=chess test show_fonts vgatest
 
 all: $(PROGS)
-ifeq "$(TOPDIR)" "/Users/greg/net/elks-gh"
-	cp -p $(PROGS) $(TOPDIR)/elkscmd/rootfs_template/root
-endif
+#ifeq "$(TOPDIR)" "/Users/greg/net/elks-gh"
+#	cp -p $(PROGS) $(TOPDIR)/elkscmd/rootfs_template/root
+#endif
 
 show_fonts: show_fonts.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)

--- a/examples/Makefile.elks
+++ b/examples/Makefile.elks
@@ -6,9 +6,9 @@
 #   ./copyc86.sh
 #   make kimage (quickly builds image)
 
-INCLUDES=-I.
-C86LIB=.
-BIN=./
+INCLUDES=-I/usr/include -I/usr/include/c86
+C86LIB=/usr/lib
+BIN=/usr/bin/
 
 # Uncomment the following lines to build on host using make86, then run:
 #   'make86 -f Makefile.elks TOPDIR=/Users/greg/net/elks-gh all'

--- a/examples/test.c
+++ b/examples/test.c
@@ -1,9 +1,25 @@
-//#include <stdio.h>
-//#include <stdlib.h>
-//#include <unistd.h>
+/* test all header files */
+#include <alloca.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+//#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/select.h>
+
 #include "cprintf.h"
-int printf(const char *fmt, ...);
-extern char **environ;
+
+//int printf(const char *fmt, ...);
+//extern char **environ;
 
 int main(int ac, char **av)
 {


### PR DESCRIPTION
Updates toolchain to work when packaged as development disk using updated ELKS `copyc86.sh` script, which creates a development disk on the current target at /usr. The development disk now uses /usr/bin, /usr/include, /usr/lib and /usr/src for the toolchain, header files, C library and example source files, respectively.

Various issues were fixed during getting this working. See ELKS https://github.com/ghaerr/elks/pull/2201.

- Fix cpp86 not reporting read errors on include file 
- Add -V verbose option to show include file open/close 
- Update usage line
- Increase cpp86 to 32K heap to allow preprocessing of almost all header files in a single .c file