### PR TITLE
Don't drag in C library if 'entry start' defined in asm files

### DIFF
--- a/examples/show_fonts.s
+++ b/examples/show_fonts.s
@@ -4,7 +4,7 @@
 
     .text                   ; text section declaration
     .align 2
-    .global _main
+    entry start
 
 strlen:
     push di
@@ -111,7 +111,7 @@ print_nibble:
     ret
 
 
-_main:
+start:
     push    bp
     mov     bp, sp
     sub     sp, #4

--- a/ld/linksyms.c
+++ b/ld/linksyms.c
@@ -35,7 +35,7 @@ bool_pt argreloc_output;
 	return;
     }
 #endif
-    if ((symptr = findsym("_start")) != NUL_PTR ||
+    if ((symptr = findsym("start")) != NUL_PTR ||
         (symptr = findsym("_main")) != NUL_PTR)
 	entrysym(symptr);
     do


### PR DESCRIPTION
Allows assembly programs to be written using 'entry start' (instead of .global _main) that won't increase the size of executables by pulling in libc86.a, even if specified in the link command line.

Changes ld86 to use 'start' or '_main' as valid automatic program entry symbols (rather than previous '_start').

examples/show_fonts.s is modified, as preferred solution for #44.