### PR TITLE
Add 640x480 graphics and keyboard/mouse event handling routines for C86

### DIFF
--- a/ecc
+++ b/ecc
@@ -97,7 +97,7 @@ for PROG in $@
     echo $CC $CFLAGS ${PROG%.c}.i ${PROG%.c}.as
     $CC $CFLAGS ${PROG%.c}.i ${PROG%.c}.as
     echo $AS $ASFLAGS -o ${PROG%.c}.o ${PROG%.c}.as
-    $AS $ASFLAGS -o ${PROG%.c}.o ${PROG%.c}.as
+    $AS $ASFLAGS -o ${PROG%.c}.o -l ${PROG%.c}.lst ${PROG%.c}.as
     OBJS="$OBJS ${PROG%.c}.o"
     if [ $DOLINK -eq 1 ]; then rm ${PROG%.c}.i ${PROG%.c}.as; fi
   done

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -37,13 +37,13 @@ NASMFLAGS=-f as86
 	$(AS) $(ASFLAGS) -o $*.o -l $*.lst $*.as
 
 %.o: %.s
-	$(AS) $(ASFLAGS) -o $*.o $*.s
+	$(AS) $(ASFLAGS) -o $*.o -l $*.lst $*.s
 
 ##### End of standardized section #####
 
 #DEFINES+=
 
-PROGS=chess test show_fonts vgatest
+PROGS=chess test show_fonts vgatest evtest
 
 all: $(PROGS)
 #ifeq "$(TOPDIR)" "/Users/greg/net/elks-gh"
@@ -53,18 +53,23 @@ all: $(PROGS)
 show_fonts: show_fonts.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
-.PRECIOUS: test.i test.as cprintf.i cprintf.as
+#.PRECIOUS: test.i test.as cprintf.i cprintf.as
 test: test.o cprintf.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-.PRECIOUS: chess.i chess.as
+#.PRECIOUS: chess.i chess.as
 chess: chess.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-.PRECIOUS: vgatest.i vgatest.as
-vgatest: vgatest.o
+#.PRECIOUS: vgatest.i vgatest.as graphics.i graphics.as
+vgatest: vgatest.o graphics.o vga-4bp.o event.o mouse.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	cp vgatest $(TOPDIR)/elkscmd/rootfs_template/root
 
+#.PRECIOUS: evtest.i evtest.as event.i event.as mouse.i mouse.as
+evtest: evtest.o event.o mouse.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	cp evtest $(TOPDIR)/elkscmd/rootfs_template/root
 
 clean:
 	rm -f *.o *.as *.i *.lst $(PROGS)

--- a/examples/Makefile.elks
+++ b/examples/Makefile.elks
@@ -45,8 +45,7 @@ LDLIBS=-lc86
 
 ##### End of standardized section #####
 
-#PROGS=chess test show_fonts vgatest
-PROGS=chess test
+PROGS=vgatest evtest chess test show_fonts
 
 all: $(PROGS)
 
@@ -59,7 +58,10 @@ test: test.o cprintf.o
 show_fonts: show_fonts.o
 	$(LD) $(LDFLAGS) -o $@ $^
 
-vgatest: vgatest.o
+vgatest: vgatest.o graphics.o vga-4bp.o event.o mouse.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+evtest: evtest.o event.o mouse.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:

--- a/examples/event.c
+++ b/examples/event.c
@@ -60,41 +60,41 @@ quit:
             return 0;
         }
         if (FD_ISSET(0, &fdset))
-		{
+        {
             unsigned char buf[1];
             if (read(0, buf, sizeof(buf)) > 0)
-			{
+            {
                 if (buf[0] == '\033')
                     goto quit;          /* quit on ESC! */
                 event->keychar = buf[0];
-				event->type = EVT_KEYCHAR;
-				return 1;
+                event->type = EVT_KEYCHAR;
+                return 1;
             }
         }
         if (FD_ISSET(mouse_fd, &fdset))
-		{
+        {
             int x, y, w, b;
             static int lastx = -1, lasty = -1, lastb = 0;
             if (read_mouse(&x, &y, &w, &b))
-			{
+            {
                 if (b & (BUTTON_SCROLLUP|BUTTON_SCROLLDN))
-				{
+                {
                     event->type = EVT_MOUSEWHEEL;
-					event->y = w * SCROLLFACTOR;
+                    event->y = w * SCROLLFACTOR;
                     lastb = b;
                     return 1;
                 }
                 if (b != lastb)
-				{
+                {
                     if ((b & BUTTON_L) ^ (lastb & BUTTON_L))
-					{
+                    {
                         event->type = (b & BUTTON_L)? EVT_MOUSEDOWN: EVT_MOUSEUP;
                         event->button = BUTTON_L;
                         event->x = posx;
                         event->y = posy;
                     }
-					else if ((b & BUTTON_R) ^ (lastb & BUTTON_R))
-					{
+                    else if ((b & BUTTON_R) ^ (lastb & BUTTON_R))
+                    {
                         event->type = (b & BUTTON_R)? EVT_MOUSEDOWN: EVT_MOUSEUP;
                         event->button = BUTTON_R;
                         event->x = posx;
@@ -104,7 +104,7 @@ quit:
                     return 1;
                 }
                 if (x != lastx || y != lasty)
-				{
+                {
                     event->type = EVT_MOUSEMOVE;
                     posx += x;
                     posy += y;
@@ -134,20 +134,20 @@ int event_poll(struct event *event)
     static struct event ev;     /* ev.type inited to 0 (=EVT_NONE) */
 
     if (event == NULL)
-	{
+    {
         /* only indicate whether event found, don't dequeue */
         if (ev.type == EVT_NONE)
             event_wait_timeout(&ev, 0);     /* 0 timeout = don't block */
-		return ev.type;
+        return ev.type;
     }
 
     /* always deqeue if event found */
     if (ev.type)
-	{
+    {
         *event = ev;
         ev.type = EVT_NONE;
     }
-	else event_wait_timeout(event, 0);
+    else event_wait_timeout(event, 0);
     return event->type;
 }
 
@@ -161,7 +161,7 @@ int event_open(void)
 
 
 #if DEBUG
-	atexit(event_close);
+    atexit(event_close);
     signal(SIGHUP, catch_signals);
     signal(SIGABRT, catch_signals);
     signal(SIGSEGV, catch_signals);

--- a/examples/event.c
+++ b/examples/event.c
@@ -1,0 +1,196 @@
+/*
+ * Keyboard and mouse event handling for C86 Graphics
+ *
+ * 1 Feb 2025 Greg Haerr
+ */
+
+#include "event.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <time.h>
+#include <sys/select.h>
+#include <termios.h>
+#include <errno.h>
+
+int SCREENWIDTH = 640;              /* for mouse clipping, set in graphics_open */
+int SCREENHEIGHT = 480;
+#define SCROLLFACTOR        4       /* multiply factor for scrollwheel */
+
+static struct termios orig;
+int mouse_fd = -1;
+static int posx, posy;              /* cursor position */
+
+static void open_keyboard(void);
+static void close_keyboard(void);
+
+/* wait for event with timeout; msec timeout 0 to poll, timeout -1 to block */
+int event_wait_timeout(struct event *e, int timeout)
+{
+    struct event *event = e;
+    int ret;
+    fd_set fdset;
+    struct timeval timeint, *tv;
+
+    if (timeout == -1)
+        tv = NULL;
+    else {              /* FIXME just poll, ignore timeout for now */
+        timeint.tv_sec = 0;
+        timeint.tv_usec = 0;
+        tv = &timeint;
+    }
+    FD_ZERO(&fdset);
+    FD_SET(mouse_fd, &fdset);
+    FD_SET(0, &fdset);
+
+    for (;;)
+    {
+        ret = select(mouse_fd + 1, &fdset, NULL, NULL, tv);
+        if (ret == 0)
+        {
+            event->type = EVT_TIMEOUT;
+            return 1;
+        }
+        if (ret < 0)
+        {
+            if (errno == EINTR)
+                continue;
+quit:
+            event->type = EVT_QUIT;
+            return 0;
+        }
+        if (FD_ISSET(0, &fdset))
+		{
+            unsigned char buf[1];
+            if (read(0, buf, sizeof(buf)) > 0)
+			{
+                if (buf[0] == '\033')
+                    goto quit;          /* quit on ESC! */
+                event->keychar = buf[0];
+				event->type = EVT_KEYCHAR;
+				return 1;
+            }
+        }
+        if (FD_ISSET(mouse_fd, &fdset))
+		{
+            int x, y, w, b;
+            static int lastx = -1, lasty = -1, lastb = 0;
+            if (read_mouse(&x, &y, &w, &b))
+			{
+                if (b & (BUTTON_SCROLLUP|BUTTON_SCROLLDN))
+				{
+                    event->type = EVT_MOUSEWHEEL;
+					event->y = w * SCROLLFACTOR;
+                    lastb = b;
+                    return 1;
+                }
+                if (b != lastb)
+				{
+                    if ((b & BUTTON_L) ^ (lastb & BUTTON_L))
+					{
+                        event->type = (b & BUTTON_L)? EVT_MOUSEDOWN: EVT_MOUSEUP;
+                        event->button = BUTTON_L;
+                        event->x = posx;
+                        event->y = posy;
+                    }
+					else if ((b & BUTTON_R) ^ (lastb & BUTTON_R))
+					{
+                        event->type = (b & BUTTON_R)? EVT_MOUSEDOWN: EVT_MOUSEUP;
+                        event->button = BUTTON_R;
+                        event->x = posx;
+                        event->y = posy;
+                    }
+                    lastb = b;
+                    return 1;
+                }
+                if (x != lastx || y != lasty)
+				{
+                    event->type = EVT_MOUSEMOVE;
+                    posx += x;
+                    posy += y;
+                    if (posx < 0) posx = 0;
+                    if (posy < 0) posy = 0;
+                    if (posx >= SCREENWIDTH) posx = SCREENWIDTH - 1;
+                    if (posy >= SCREENHEIGHT) posy = SCREENHEIGHT - 1;
+                    event->x = posx;
+                    event->y = posy;
+                    event->xrel = x;
+                    event->yrel = y;
+                    event->button = b;
+                    lastx = x;
+                    lasty = y;
+                    return 1;
+                }
+            }
+        }
+    }
+    event->type = EVT_NONE;
+    return 1;
+}
+
+/* check for event but don't dequeue if event == NULL */
+int event_poll(struct event *event)
+{
+    static struct event ev;     /* ev.type inited to 0 (=EVT_NONE) */
+
+    if (event == NULL)
+	{
+        /* only indicate whether event found, don't dequeue */
+        if (ev.type == EVT_NONE)
+            event_wait_timeout(&ev, 0);     /* 0 timeout = don't block */
+		return ev.type;
+    }
+
+    /* always deqeue if event found */
+    if (ev.type)
+	{
+        *event = ev;
+        ev.type = EVT_NONE;
+    }
+	else event_wait_timeout(event, 0);
+    return event->type;
+}
+
+int event_open(void)
+{
+    if (open_mouse() < 0)
+        return -1;
+    open_keyboard();
+    posx = SCREENWIDTH / 2;
+    posy = SCREENHEIGHT / 2;
+
+
+#if DEBUG
+	atexit(event_close);
+    signal(SIGHUP, catch_signals);
+    signal(SIGABRT, catch_signals);
+    signal(SIGSEGV, catch_signals);
+#endif
+    return 0;
+}
+
+void event_close(void)
+{
+    close_mouse();
+    close_keyboard();
+}
+
+static void open_keyboard(void)
+{
+    struct termios new;
+
+    tcgetattr(0, &orig);
+    new = orig;
+    new.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    //new.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT);
+    //new.c_cflag &= ~(CSIZE | PARENB);
+    new.c_cflag |= CS8;
+    new.c_cc[VMIN] = 1;     /* =1 required for lone ESC key processing */
+    new.c_cc[VTIME] = 0;
+    tcsetattr(0, TCSAFLUSH, &new);
+}
+
+static void close_keyboard(void)
+{
+    tcsetattr(0, TCSANOW, &orig);
+}

--- a/examples/event.h
+++ b/examples/event.h
@@ -1,0 +1,42 @@
+/* event.h */
+
+/* event types */
+#define EVT_NONE            0
+#define EVT_TIMEOUT         1
+#define EVT_QUIT            2
+#define EVT_KEYCHAR         3
+#define EVT_MOUSEDOWN       4
+#define EVT_MOUSEUP         5
+#define EVT_MOUSEMOVE       6
+#define EVT_MOUSEWHEEL      7
+
+/* mouse button values */
+#define BUTTON_L            0x01      /* left button*/
+#define BUTTON_R            0x02      /* right button*/
+#define BUTTON_M            0x10      /* middle*/
+#define BUTTON_SCROLLUP     0x20      /* wheel up*/
+#define BUTTON_SCROLLDN     0x40      /* wheel down*/
+
+struct event {
+    int     type;           /* event type */
+    int     keychar;        /* keyboard character on EVT_KEYBOARD */
+    int     button;         /* mouse BUTTON_xxx on EVT_MOUSE* events */
+    int     x;              /* mouse or wheel location on EVT_MOUSE* ior EVT_WHEEL* */
+    int     y;
+    int     xrel;           /* relative location on EVT_WHEEL* events */
+    int     yrel;
+};
+
+/* event handling */
+int event_open(void);
+void event_close(void);
+
+/* wait/poll on event, timeout in msecs or = -1 blocking */
+int event_wait_timeout(struct event *e, int timeout);   /* returns 0 on EVT_QUIT */
+int event_poll(struct event *event);                    /* polls if event == NULL */
+
+/* Microsoft, PC/Logitch and PS/2 mouse decoding */
+int open_mouse(void);
+int read_mouse(int *dx, int *dy, int *dw, int *bp);
+void close_mouse(void);
+

--- a/examples/evtest.c
+++ b/examples/evtest.c
@@ -22,16 +22,16 @@ int main(int ac, char **av)
             printf("char %c\n", e.keychar);
             break;
         case EVT_MOUSEDOWN:
-			printf("  down   x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            printf("  down   x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
             break;
         case EVT_MOUSEUP:
-			printf("  up     x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            printf("  up     x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
             break;
         case EVT_MOUSEMOVE:
-			printf("  move   x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            printf("  move   x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
             break;
         case EVT_MOUSEWHEEL:
-			printf("  scroll x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            printf("  scroll x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
             break;
         default:
             printf("unknown type %d\n", e.type);

--- a/examples/evtest.c
+++ b/examples/evtest.c
@@ -1,0 +1,43 @@
+/* event testing for C86 */
+#include <stdio.h>
+#include <stdlib.h>
+#include "event.h"
+
+int main(int ac, char **av)
+{
+    struct event e;
+
+    if (event_open() < 0)
+        exit(1);
+
+    while (event_wait_timeout(&e, -1)) {
+        switch (e.type) {
+        case EVT_NONE:
+            printf("none\n");
+            break;
+        case EVT_TIMEOUT:
+            printf("timeout\n");
+            break;
+        case EVT_KEYCHAR:
+            printf("char %c\n", e.keychar);
+            break;
+        case EVT_MOUSEDOWN:
+			printf("  down   x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            break;
+        case EVT_MOUSEUP:
+			printf("  up     x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            break;
+        case EVT_MOUSEMOVE:
+			printf("  move   x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            break;
+        case EVT_MOUSEWHEEL:
+			printf("  scroll x:%4d, y:%4d, b:%2d\n", e.x, e.y, e.button);
+            break;
+        default:
+            printf("unknown type %d\n", e.type);
+            break;
+        }
+    }
+    event_close();
+    return 0;
+}

--- a/examples/graphics.c
+++ b/examples/graphics.c
@@ -1,0 +1,97 @@
+/*
+ * VGA/PAL Graphics for C86
+ *  Supports 16-color VGA and 256 color PAL modes
+ *
+ * 1 Feb 2025 Greg Haerr
+ */
+
+#include <stdio.h>
+#include "graphics.h"
+
+int SCREENWIDTH;                /* initialized by graphics_open */
+int SCREENHEIGHT;
+
+/* use BIOS to set video mode */
+static void set_mode(int mode)
+{
+    asm(
+        "push   si\n"
+        "push   di\n"
+        "push   ds\n"
+        "push   es\n"
+        "mov    ax,[bp+4]\n"    /* AH=0, AL=mode */
+        "int    0x10\n"
+        "pop    es\n"
+        "pop    ds\n"
+        "pop    di\n"
+        "pop    si\n"
+    );
+}
+
+int graphics_open(int mode)
+{
+    switch (mode) {
+    case VGA_640x480x16:
+        SCREENWIDTH = 640;
+        SCREENHEIGHT = 480;
+        set_mode(mode);
+        vga_init();
+        break;
+    case PAL_320x200x256:
+        SCREENWIDTH = 320;
+        SCREENHEIGHT = 200;
+        set_mode(mode);
+        break;
+    default:
+        printf("Unsupported mode: %02x\n", mode);
+        return -1;
+    }
+    return 0;
+}
+
+void graphics_close(void)
+{
+    set_mode(TEXT_MODE);
+}
+
+/* PAL write color byte at video offset */
+static void pal_writevid(unsigned int offset, int c)
+{
+    asm(
+        "push   ds\n"
+        "push   bx\n"
+        "mov    ax,#0xA000\n"
+        "mov    ds,ax\n"
+        "mov    bx,[bp+4]\n"    /* offset */
+        "mov    al,[bp+6]\n"    /* color */
+        "mov    [bx],al\n"
+        "pop    bx\n"
+        "pop    ds\n"
+    );
+}
+
+/* PAL draw a pixel at x, y with 8-bit color c */
+void pal_drawpixel(int x,int y, int color)
+{
+    pal_writevid(y*SCREENWIDTH + x, color);
+}
+
+/* PAL fill rectangle with color c */
+void pal_fill_rect(int x1, int y1, int x2, int y2, int c)
+{
+    int x, offset;
+
+    while(y1 <= y2) {
+        offset = y1*SCREENWIDTH + x1;
+        for(x = x1; x <= x2; x++)
+            pal_writevid(offset++, 0);
+        y1++;
+    }
+}
+
+/* VGA fill rectangle with color c */
+void vga_fill_rect(int x1, int y1, int x2, int y2, int c)
+{
+    while(y1 <= y2)
+        vga_drawhline(x1, x2, y1++, c);
+}

--- a/examples/graphics.h
+++ b/examples/graphics.h
@@ -1,0 +1,25 @@
+/* graphics.h */
+
+/* supported graphics modes in graphics_open */
+#define VGA_640x480x16      0x12        /* 640x480 16 color/4bpp */
+#define PAL_320x200x256     0x13        /* 320x200 256 color/8bpp */
+#define TEXT_MODE           0x03        /* 80x25 text mode */
+
+extern int SCREENWIDTH;                 /* set by graphics_open */
+extern int SCREENHEIGHT;
+
+/* start/stop graphics mode */
+int graphics_open(int mode);
+void graphics_close(void);
+
+/* VGA 16 color, 4bpp routines */
+void vga_init(void);
+void vga_drawpixel(int x, int y, int c);
+void vga_drawhline(int x1, int x2, int y, int c);
+void vga_drawvline(int x, int y1, int y2, int c);
+int vga_readpixel(int x, int y);
+void vga_fill_rect(int x1, int y1, int x2, int y2, int c);
+
+/* PAL 256 color 8bpp routines */
+void pal_drawpixel(int x,int y, int color);
+void pal_fill_rect(int x1, int y1, int x2, int y2, int c);

--- a/examples/mouse.c
+++ b/examples/mouse.c
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ * Portions Copyright (c) 1991 David I. Bell
+ * Permission is granted to use, distribute, or modify this source,
+ * provided that this copyright notice remains intact.
+ *
+ * Opens a serial port directly, and interprets serial data.
+ * Microsoft, PC/Logitech and PS/2 mice are supported.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <termios.h>
+#include "event.h"
+
+/* configurable options */
+#define MOUSE_DEVICE "/dev/ttyS0"   /* mouse tty device*/
+#define MOUSE_MICROSOFT     1       /* microsoft mouse*/
+#define MOUSE_PC            0       /* pc/logitech mouse*/
+#define MOUSE_PS2           0       /* PS/2 mouse */
+#define MAX_BYTES   128             /* number of bytes for buffer*/
+
+/* states for the mouse*/
+#define IDLE            0       /* start of byte sequence */
+#define XSET            1       /* setting x delta */
+#define YSET            2       /* setting y delta */
+#define XADD            3       /* adjusting x delta */
+#define YADD            4       /* adjusting y delta */
+
+/* pc and ms button codes*/
+#define PC_LEFT_BUTTON      4
+#define PC_MIDDLE_BUTTON    2
+#define PC_RIGHT_BUTTON     1
+#define MS_LEFT_BUTTON      2
+#define MS_RIGHT_BUTTON     1
+
+/* Bit fields in the bytes sent by the mouse.*/
+#define TOP_FIVE_BITS       0xf8
+#define BOTTOM_THREE_BITS   0x07
+#define TOP_BIT             0x80
+#define SIXTH_BIT           0x40
+#define BOTTOM_TWO_BITS     0x03
+#define THIRD_FOURTH_BITS   0x0c
+#define BOTTOM_SIX_BITS     0x3f
+
+int     mouse_fd;           /* file descriptor for mouse */
+
+/* local data*/
+static int      rawmode;    /* show raw mouse data */
+static int      state;      /* IDLE, XSET, ... */
+static int      buttons;    /* current mouse buttons pressed*/
+static int      availbuttons;   /* which buttons are available */
+static int      xd;         /* change in x */
+static int      yd;         /* change in y */
+
+static int      left;       /* because the button values change */
+static int      middle;     /* between mice, the buttons are */
+static int      right;      /* redefined */
+
+static unsigned char    *bp;/* buffer pointer */
+static int      nbytes;     /* number of bytes left */
+static unsigned char    buffer[MAX_BYTES];  /* data bytes read */
+static int      (*parse)(); /* parse routine */
+
+/* local routines*/
+#if MOUSE_PC
+static int      parsePC(int);       /* routine to interpret PC mouse */
+#endif
+#if MOUSE_MICROSOFT
+static int      parseMS(int);       /* routine to interpret MS mouse */
+#endif
+
+/*
+ * Open up the mouse device.
+ * Returns the fd if successful, or negative if unsuccessful.
+ */
+int open_mouse(void)
+{
+    struct termios termios;
+
+    /* set button bits and parse procedure*/
+#if MOUSE_PC
+    /* pc or logitech mouse*/
+    left = PC_LEFT_BUTTON;
+    middle = PC_MIDDLE_BUTTON;
+    right = PC_RIGHT_BUTTON;
+    parse = parsePC;
+#elif MOUSE_MICROSOFT
+    /* microsoft mouse*/
+    left = MS_LEFT_BUTTON;
+    right = MS_RIGHT_BUTTON;
+    middle = 0;
+    parse = parseMS;
+#endif
+
+    /* open mouse port*/
+    mouse_fd = open(MOUSE_DEVICE, O_RDWR | O_EXCL | O_NOCTTY | O_NONBLOCK);
+    if (mouse_fd < 0) {
+        printf("Can't open mouse %s, error %d\n", MOUSE_DEVICE, errno);
+        return -1;
+    }
+
+    /* set rawmode serial port using termios*/
+    if (tcgetattr(mouse_fd, &termios) < 0) {
+        printf("Can't get termio on %s, error %d\n", MOUSE_DEVICE, errno);
+        close(mouse_fd);
+        return -1;
+    }
+
+    if(cfgetispeed(&termios) != B1200)
+        cfsetispeed(&termios, (speed_t)B1200);
+
+    termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
+    //termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
+    //termios.c_cflag &= ~(CSIZE | PARENB);
+    termios.c_cflag |= CS8;
+    termios.c_cc[VMIN] = 0;
+    termios.c_cc[VTIME] = 0;
+    if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0) {
+        printf("Can't set termio on %s, error %d\n", MOUSE_DEVICE, errno);
+        close(mouse_fd);
+        return -1;
+    }
+
+#if MOUSE_PS2
+    /* sequence to mouse device to send ImPS/2 events*/
+    static const unsigned char imps2[] = { 0xf3, 200, 0xf3, 100, 0xf3, 80 };
+
+    /* try to switch the mouse to ImPS/2 protocol*/
+    if (write(mouse_fd, imps2, sizeof(imps2)) != sizeof(imps2))
+        /*printf("Can't switch to ImPS/2 protocol\n")*/;
+    if (read(mouse_fd, buf, 4) != 1 || buf[0] != 0xF4)
+        /*printf("Failed to switch to ImPS/2 protocol.\n")*/;
+#endif
+
+    /* initialize data*/
+    availbuttons = left | middle | right;
+    state = IDLE;
+    nbytes = 0;
+    buttons = 0;
+    xd = 0;
+    yd = 0;
+
+    return mouse_fd;
+}
+
+void close_mouse(void)
+{
+    if (mouse_fd >= 0)
+        close(mouse_fd);
+    mouse_fd = -1;
+}
+
+#if MOUSE_PS2
+/* IntelliMouse PS/2 protocol uses four byte reports
+ * (PS/2 protocol omits last byte):
+ *      Bit   7     6     5     4     3     2     1     0
+ * --------+-----+-----+-----+-----+-----+-----+-----+-----
+ *  Byte 0 |  0     0   Neg-Y Neg-X   1    Mid  Right Left
+ *  Byte 1 |  X     X     X     X     X     X     X     X
+ *  Byte 2 |  Y     Y     Y     Y     Y     Y     Y     Y
+ *  Byte 3 |  W     W     W     W     W     W     W     W
+ *
+ * XXXXXXXX, YYYYYYYY, and WWWWWWWW are 8-bit two's complement values
+ * indicating changes in x-coordinate, y-coordinate, and scroll wheel.
+ * That is, 0 = no change, 1..127 = positive change +1 to +127,
+ * and 129..255 = negative change -127 to -1.
+ *
+ * Left, Right, and Mid are the three button states, 1 if being depressed.
+ * Neg-X and Neg-Y are set if XXXXXXXX and YYYYYYYY are negative, respectively.
+ */
+int read_mouse(int *dx, int *dy, int *dw, int *bp)
+{
+    int n, x, y, w, left, middle, right, button;
+    unsigned char data[4];
+
+    n = read(mouse_fd, data, sizeof(data));
+    if (n != 3 && n != 4)
+        return 0;
+
+    button = 0;
+    left = data[0] & 0x1;
+    right = data[0] & 0x2;
+    middle = data[0] & 0x4;
+
+    if (left)   button |= BUTTON_L;
+    if (middle) button |= BUTTON_M;
+    if (right)  button |= BUTTON_R;
+
+    x =   (signed char) data[1];
+    y = - (signed char) data[2];  /* y axis flipped between conventions */
+    if (n == 4) {
+        w = (signed char) data[3];
+        if (w > 0)
+            button |= BUTTON_SCROLLUP;
+        if (w < 0)
+            button |= BUTTON_SCROLLDN;
+    }
+    *dx = x;
+    *dy = y;       
+    *dw = w;
+    *bp = button;
+    return 1;
+}
+#endif
+
+#if MOUSE_MICROSOFT | MOUSE_PC
+/*
+ * Attempt to read bytes from the mouse and interpret them.
+ * Returns -1 on error, 0 if either no bytes were read or not enough
+ * was read for a complete state, or 1 if the new state was read.
+ * When a new state is read, the current buttons and x and y deltas
+ * are returned.  This routine does not block.
+ */
+int read_mouse(int *dx, int *dy, int *dz, int *bptr)
+{
+    int b;
+
+    /*
+     * If there are no more bytes left, then read some more,
+     * waiting for them to arrive.  On a signal or a non-blocking
+     * error, return saying there is no new state available yet.
+     */
+    if (nbytes <= 0) {
+        bp = buffer;
+        nbytes = read(mouse_fd, bp, MAX_BYTES);
+        if (nbytes < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                return 0;
+            return -1;
+        }
+    }
+    if (rawmode) {
+        while (nbytes-- > 0)
+            printf("%02x ", *bp++);
+        return 0;
+    }
+
+    /*
+     * Loop over all the bytes read in the buffer, parsing them.
+     * When a complete state has been read, return the results,
+     * leaving further bytes in the buffer for later calls.
+     */
+    while (nbytes-- > 0) {
+        if ((*parse)((int) *bp++)) {
+            *dx = xd;
+            *dy = yd;
+            *dz = 0;
+            b = 0;
+            if(buttons & left)
+                b |= BUTTON_L;
+            if(buttons & right)
+                b |= BUTTON_R;
+            if(buttons & middle)
+                b |= BUTTON_M;
+            *bptr = b;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+#endif
+
+#if MOUSE_PC
+/*
+ * Input routine for PC mouse.
+ * Returns nonzero when a new mouse state has been completed.
+ */
+static int parsePC(int byte)
+{
+    int sign;           /* sign of movement */
+
+    switch (state) {
+        case IDLE:
+            if ((byte & TOP_FIVE_BITS) == TOP_BIT) {
+                buttons = ~byte & BOTTOM_THREE_BITS;
+                state = XSET;
+            }
+            break;
+
+        case XSET:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            xd = byte * sign;
+            state = YSET;
+            break;
+
+        case YSET:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            yd = -byte * sign;
+            state = XADD;
+            break;
+
+        case XADD:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            xd += byte * sign;
+            state = YADD;
+            break;
+
+        case YADD:
+            sign = 1;
+            if (byte > 127) {
+                byte = 256 - byte;
+                sign = -1;
+            }
+            yd -= byte * sign;
+            state = IDLE;
+            return 1;
+    }
+    return 0;
+}
+#endif
+
+#if MOUSE_MICROSOFT
+/*
+ * Input routine for Microsoft mouse.
+ * Returns nonzero when a new mouse state has been completed.
+ */
+static int parseMS(int byte)
+{
+    switch (state) {
+        case IDLE:
+            if (byte & SIXTH_BIT) {
+                buttons = (byte >> 4) & BOTTOM_TWO_BITS;
+                yd = ((byte & THIRD_FOURTH_BITS) << 4);
+                xd = ((byte & BOTTOM_TWO_BITS) << 6);
+                state = XADD;
+            }
+            break;
+
+        case XADD:
+            xd |= (byte & BOTTOM_SIX_BITS);
+            state = YADD;
+            break;
+
+        case YADD:
+            yd |= (byte & BOTTOM_SIX_BITS);
+            state = IDLE;
+            if (xd > 127)
+                xd -= 256;
+            if (yd > 127)
+                yd -= 256;
+            return 1;
+    }
+    return 0;
+}
+#endif
+
+#if TEST
+int main(int argc, char **argv)
+{
+    int x, y, z, b;
+
+    rawmode = (argc > 1);
+
+    if(open_mouse() < 0)
+        return 1;
+
+    printf("[Mouse test, ^C to quit]\n");
+    while(1) {
+        if(read_mouse(&x, &y, &z, &b) == 1) {
+            printf("x:%4d, y:%4d, b:%2d\n", x, y, b);
+        }
+    }
+    return 0;
+}
+#endif

--- a/examples/vga-4bp.s
+++ b/examples/vga-4bp.s
@@ -1,0 +1,389 @@
+; Routines to draw pixels and lines for EGA/VGA 16 color 4 planes modes.
+; High speed version for C86 using AS86 assembly
+; Supports  the following EGA and VGA 16 color modes:
+;       640x480 16 color (mode 0x12)
+;       350 line modes
+;       200 line modes
+;
+; The algorithms for some of these routines are taken from the book:
+; Programmer's Guide to PC and PS/2 Video Systems by Richard Wilton.
+;
+; Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+; Copyright (c) 1991 David I. Bell
+; Permission is granted to use, distribute, or modify this source,
+; provided that this copyright notice remains intact.
+;
+; 1 Feb 2025 Greg Haerr rewritten for ELKS AS86
+;
+        use16   86
+        .text
+BYTESPERLN  = 80                ; number of bytes in scan line
+arg1        = 4                 ; small model
+
+;
+; void vga_init(void)
+;
+; C version:
+;   set_enable_sr(0x0f);
+;   set_op(0);
+;   set_write_mode(0);
+;
+    .global _vga_init
+_vga_init:
+        mov     dx, #0x03ce     ; graphics controller port address
+        mov     ax, #0xff01     ; set enable set/reset register 1 mask FF
+        out     dx,ax
+
+        mov     ax, #0x0003     ; data rotate register 3 NOP 0
+        out     dx, ax
+
+        mov     ax, #0x0005     ; set graphics mode register 5 write mode 0
+        out     dx, ax          ; [load value 0 into mode register 5]
+        ret
+
+;
+; Draw an individual pixel.
+; void vga_drawpixel(int x, int y, int color);
+;
+; C version:
+;   static unsigned char mask[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
+;   //set_op(0);
+;   set_color(c);
+;   select_mask();
+;   set_mask(mask[x&7]);
+;
+        .global  _vga_drawpixel
+_vga_drawpixel:
+        push    bp
+        mov     bp, sp
+
+        ;mov     dx, #0x03ce     ; graphics controller port address
+        ;mov     ax, #0x0003     ; data rotate register 3 NOP 0
+        ;out     dx, ax
+
+        mov     cx, arg1[bp]    ; CX := x
+        mov     bx, cx          ; BX := x
+        mov     ax, arg1+2[bp]  ; AX := y
+
+        mov     dx, #BYTESPERLN ; AX := [y * BYTESPERLN]
+        mul     dx
+
+        and     cl, #7          ; CL := x & 7
+        xor     cl, #7          ; CL := 7 - (x & 7)
+        mov     ch, #1          ; CH := 1 << (7 - (x & 7))
+        shl     ch, cl          ; CH is mask
+
+        mov     cl, #3          ; BX := x / 8
+        shr     bx, cl
+        add     bx, ax          ; BX := [y * BYTESPERLN] + [x / 8]
+
+        mov     dx, #0x03ce     ; graphics controller port address
+        xor     ax, ax          ; set color register 0
+        mov     ah, arg1+4[bp]  ; color pixel value
+        out     dx, ax
+
+        mov     al, #8          ; set bit mask register 8
+        mov     ah, ch          ; [load bit mask into register 8]
+        out     dx, ax
+
+        mov     cx, ds
+        mov     ax, #0xA000     ; DS := EGA buffer segment address
+        mov     ds, ax
+        or      [bx],al         ; quick rmw to set pixel
+        mov     ds, cx          ; restore registers and return
+
+        ;mov     ax, #0x0005     ; restore default write mode 0
+        ;out     dx, ax          ; [load value 0 into mode register 5]
+
+        pop     bp
+        ret
+
+;
+; Draw a horizontal line from x1,1 to x2,y including final point
+; void vga_drawhine(int x1, int x2, int y, int color);
+;
+; C version:
+;   set_color(c);
+;   //set_op(0);
+;   char far *dst = SCREENBASE + x1 / 8 + y * BYTESPERLN;
+;   select_mask();
+;   if (x1 / 8 == x2 / 8) {
+;       set_mask((0xff >> (x1 & 7)) & (0xff << (7 - x2 & 7)));
+;       *dst |= 1;
+;   } else {
+;       set_mask(0xff >> (x1 & 7));
+;       *dst++ |= 1;
+;       set_mask(0xff);
+;       last = SCREENBASE + x2 / 8 + y * BYTESPERLN;
+;       while (dst < last)
+;           *dst++ = 1;
+;       set_mask(0xff << (7 - x2 & 7));
+;       *dst |= 1;
+;   }
+
+x1      = arg1          ; first X coordinate
+x2      = arg1 + 2      ; second X coordinate
+y       = arg1 + 4      ; second Y coordinate
+color   = arg1 + 6      ; pixel value
+
+        .global _vga_drawhline
+ _vga_drawhline:
+        push    bp              ; setup stack frame and preserve registers
+        mov     bp, sp
+        push    si
+        push    di
+        push    es
+        push    ds
+
+        mov     dx, #0x03ce     ; Graphics Controller port address
+        ;mov     ax, #0x0003     ; data rotate register 3 NOP 0
+        ;out     dx, ax
+
+        xor     al, al          ; set Set/Reset register 0 with color
+        mov     ah, color[bp]
+        out     dx, ax
+
+        mov     ax, #0x0f01     ; AH := bit plane mask for Enable Set/Reset
+        out     dx, ax          ; AL := Enable Set/Reset register 1
+
+        mov     ax, y[bp]
+        mov     bx, x1[bp]
+
+        ; compute pixel address
+        mov     dx, #BYTESPERLN ; AX := [row * BYTESPERLN]
+        mul     dx
+        mov     cl, bl          ; save low order column bits
+        shr     bx, #1          ; BX := [col / 8]
+        shr     bx, #1
+        shr     bx, #1
+        add     bx, ax          ; BX := [row * BYTESPERLN] + [col / 8]
+        and     cl, #7          ; CL := [col & 7]
+        xor     cl, #7          ; CL := 7 - [col & 7]
+        mov     ah, #1          ; AH := 1 << [7 - [col & 7]]    [mask]
+        mov     dx, #0xA000     ; ES := EGA buffer segment address
+        mov     es, dx          ; ES:BX -> video buffer
+                                ; AH := bit mask
+                                ; CL := number bits to shift left
+        mov     di, bx          ; ES:DI -> buffer
+        mov     dh, ah          ; DH := unshifted bit mask for left byte
+
+        not     dh
+        shl     dh, cl          ; DH := reverse bit mask for first byte
+        not     dh              ; DH := bit mask for first byte
+
+        mov     cx, x2[bp]
+        and     cl, #7
+        xor     cl, #7          ; CL := number of bits to shift left
+        mov     dl, #0xff       ; DL := unshifted bit mask for right byte
+        shl     dl, cl          ; DL := bit mask for last byte
+
+        ; determine byte offset of first and last pixel in the line
+        mov     ax, x2[bp]      ; AX := x2
+        mov     bx, x1[bp]      ; BX := x1
+
+        mov     cl, #3          ; bits to convert pixels to bytes
+
+        shr     ax, cl          ; AX := byte offset of X2
+        shr     bx, cl          ; BX := byte offset of X1
+        mov     cx, ax
+        sub     cx, bx          ; CX := [number of bytes in line] - 1
+
+        ; get Graphics Controller port address into DX
+        mov     bx, dx          ; BH := bit mask for first byte
+                                ; BL := bit mask for last byte
+        mov     dx, #0x03ce     ; DX := Graphics Controller port
+        mov     al, #8          ; AL := Bit mask Register number
+
+        ; make video buffer addressable through DS:SI
+        push    es
+        pop     ds
+        mov     si, di          ; DS:SI -> video buffer
+
+        ; set pixels in leftmost byte of the line
+        or      bh, bh
+        js      L43             ; jump if byte-aligned [x1 is leftmost]
+
+        or      cx, cx
+        jnz     L42             ; jump if more than one byte in the line
+
+        and     bl, bh          ; BL := bit mask for the line
+        jmp     L44
+
+L42:    mov     ah, bh          ; AH := bit mask for first byte
+        out     dx, ax          ; update graphics controller
+
+        movsb                   ; update bit planes
+        dec     cx
+
+        ; use a fast 8086 machine instruction to draw the remainder of the line
+L43:    mov     ah, #0xff       ; AH := bit mask
+        out     dx, ax          ; update Bit Mask register
+        rep
+        movsb                   ; update all pixels in the line
+
+        ; set pixels in the rightmost byte of the line
+
+L44:    mov     ah, bl          ; AH := bit mask for last byte
+        out     dx, ax          ; update Graphics Controller
+        movsb                   ; update bit planes
+
+        ; restore default Graphics Controller state and return to caller
+        ;xor   ax, ax          ; AH := 0, AL := 0
+        ;out   dx, ax          ; restore Set/Reset register
+        ;inc   ax              ; AH := 0, AL := 1
+        ;out   dx, ax          ; restore Enable Set/Reset register
+        ;mov   ax, #0xff08     ; AH := 0xff, AL := 0
+        ;out   dx, ax          ; restore Bit Mask register
+
+        pop     ds
+        pop     es
+        pop     di
+        pop     si
+        pop     bp
+        ret
+
+;
+; Draw a vertical line from x,y1 to x,y2 including final point
+; void vga_drawvline(int x, int y1, int y2, int color);
+;
+; C version:
+;   //set_op(0);
+;   set_color(c);
+;   select_mask();
+;   set_mask(mask[x&7]);
+;   char far *dst = SCREENBASE + x / 8 + y1 * BYTESPERLN;
+;   char far *last = SCREENBASE + x / 8 + y2 * BYTESPERLN;
+;   while (dst < last) {
+;       *dst |= 1;
+;       dst += BYTESPERLN;
+;   }
+;
+
+x       = arg1          ; first X coordinate
+y1      = arg1 + 2      ; first Y coordinate
+y2      = arg1 + 4      ; second Y coordinate
+color   = arg1 + 6      ; pixel value
+
+        .global  _vga_drawvline
+_vga_drawvline:
+        push    bp              ; setup stack frame and preserve registers
+        mov     bp, sp
+        push    ds
+
+        mov     dx, #0x03ce     ; DX := Graphics Controller port address
+        ;mov     ax, #0x0003     ; data rotate register 3 NOP 0
+        ;out     dx, ax
+
+        xor     al, al          ; set Set/Reset register 0 with color
+        mov     ah, color[bp]
+        out     dx, ax
+
+        mov     ax, #0x0f01     ; AH := bit plane mask for Enable Set/Reset
+        out     dx, ax          ; AL := Enable Set/Reset register number
+
+        ; prepare to draw vertical line
+        mov     ax, y1[bp]      ; AX := y1
+        mov     cx, y2[bp]      ; BX := y2
+        sub     cx, ax          ; CX := dy
+
+L311:   inc     cx              ; CX := number of pixels to draw
+        mov     bx, x[bp]       ; BX := x
+        push    cx              ; save register
+
+        ; compute pixel address
+        push    dx
+        mov     dx, #BYTESPERLN ; AX := [row * BYTESPERLN]
+        mul     dx
+        mov     cl, bl          ; save low order column bits
+        shr     bx, #1          ; BX := [col / 8]
+        shr     bx, #1
+        shr     bx, #1
+        add     bx, ax          ; BX := [row * BYTESPERLN] + [col / 8]
+        and     cl, #7          ; CL := [col & 7]
+        xor     cl, #7          ; CL := 7 - [col & 7]
+        mov     ah, #1          ; AH := 1 << [7 - [col & 7]]    [mask]
+        mov     dx, #0x0A000    ; DS := EGA buffer segment address
+        mov     ds, dx          ; DS:BX -> video buffer
+        pop     dx
+                                ; AH := bit mask
+                                ; CL := number bits to shift left
+        ; set up Graphics controller
+        shl     ah, cl          ; AH := bit mask in proper position
+        mov     al, #8          ; AL := Bit Mask register number 8
+        out     dx, ax
+
+        pop     cx              ; restore number of pixels to draw
+
+        ; draw the line
+        mov     dx, #BYTESPERLN ; increment for video buffer
+L1111:  or      [bx], al        ; set pixel
+        add     bx, dx          ; increment to next line
+        loop    L1111
+
+        ; restore default Graphics Controller state and return to caller
+        ;xor   ax, ax          ; AH := 0, AL := 0
+        ;out   dx, ax          ; restore Set/Reset register
+        ;inc   ax              ; AH := 0, AL := 1
+        ;out   dx, ax          ; restore Enable Set/Reset register
+        ;mov   ax, #0xff08     ; AH := 0xff, AL := 0
+        ;out   dx, ax          ; restore Bit Mask register
+
+        pop     ds
+        pop     bp
+        ret
+
+;
+; Read the value of an individual pixel.
+; int ega_readpixel(int x, int y);
+;
+        .global _vga_readpixel
+_vga_readpixel:
+        push    bp
+        mov     bp, sp
+        push    si
+        push    ds
+
+        mov     ax, arg1+2[bp]  ; AX := y
+        mov     bx, arg1[bp]    ; BX := x
+        mov     dx, #BYTESPERLN ; AX := [y * BYTESPERLN]
+        mul     dx
+
+        mov     cl, bl          ; save low order column bits
+        shr     bx, #1          ; BX := [x / 8]
+        shr     bx, #1
+        shr     bx, #1
+
+        add     bx, ax          ; BX := [y * BYTESPERLN] + [x / 8]
+
+        and     cl, #7          ; CL := [x & 7]
+        xor     cl, #7          ; CL := 7 - [x & 7]
+
+        mov     dx, #0xA000     ; DS := EGA buffer segment address
+        mov     ds, dx
+
+        mov     ch, #1          ; CH := 1 << [7 - [col & 7]]
+        shl     ch, cl          ; CH := bit mask in proper position
+
+        mov     si, bx          ; DS:SI -> region buffer byte
+        xor     bl, bl          ; BL is used to accumulate the pixel value
+
+        mov     dx, #0x03ce     ; DX := Graphics Controller port
+        mov     ax, #0x0304     ; AH := initial bit plane number 3
+                                ; AL := Read Map Select register number 4
+
+L112:   out     dx, ax          ; select bit plane
+        mov     bh, [si]        ; BH := byte from current bit plane
+        and     bh, ch          ; mask one bit
+        neg     bh              ; bit 7 of BH := 1 if masked bit = 1
+                                ; bit 7 of BH := 0 if masked bit = 0
+        rol     bx, #1          ; bit 0 of BL := next bit from pixel value
+        dec     ah              ; AH := next bit plane number
+        jge     L112
+
+        xor     ax, ax          ; AL := pixel value
+        mov     al, bl
+
+        pop     ds
+        pop     si
+        pop     bp      
+        ret

--- a/examples/vgatest.c
+++ b/examples/vgatest.c
@@ -1,74 +1,44 @@
-#define VGA_256_COLOR_MODE  0x13      /* use to set 256-color mode. */
-#define TEXT_MODE           0x03      /* use to set 80x25 text mode. */
+/* VGA graphics test for C86 */
 
-#define SCREEN_WIDTH        320       /* width in pixels of mode 0x13 */
-#define SCREEN_HEIGHT       200       /* height in pixels of mode 0x13 */
-#define NUM_COLORS          256       /* number of colors in mode 0x13 */
+#include <unistd.h>
+#include "graphics.h"
+#include "event.h"
 
-unsigned int sleep(unsigned int seconds);
+int VGA = 1;        /* =1 for VGA 640x480, =0 for PAL 320x200 mode */
 
-/**************************************************************************
- *  set_mode                                                              *
- *     Sets the video mode.                                               *
- **************************************************************************/
-
-void set_mode(int mode)
+int main(int ac, char **av)
 {
-    asm(
-        "push   si\n"
-        "push   di\n"
-        "push   ds\n"
-        "push   es\n"
-        "mov    ax,[bp+4]\n"    /* AH=0, AL=mode */
-        "int    0x10\n"
-        "pop    es\n"
-        "pop    ds\n"
-        "pop    di\n"
-        "pop    si\n"
-    );
-}
+    struct event e;
+    int c = 10;
 
-/**************************************************************************
- *  plot_pixel                                                            *
- *    Plot a pixel by directly writing to video memory, with no           *
- *    multiplication.                                                     *
- **************************************************************************/
+    if (event_open() < 0)
+      return 1;
+    if (graphics_open(VGA? VGA_640x480x16: PAL_320x200x256) < 0)
+        return 1;
 
-void writevid(unsigned int offset, unsigned int val)
-{
-    asm(
-        "push   ds\n"
-        "push   bx\n"
-        "mov    ax,#0xA000\n"
-        "mov    ds,ax\n"
-        "mov    bx,[bp+4]\n"    /* offset */
-        "mov    al,[bp+6]\n"    /* val */
-        "mov    [bx],al\n"
-        "pop    bx\n"
-        "pop    ds\n"
-    );
-}
-
-void plot_pixel(int x,int y,unsigned int color)
-{
-     /*  y*320 = y*256 + y*64 = y*2^8 + y*2^6   */
-    int offset = (y<<8)+(y<<6)+x;
-    writevid(offset, color);
-}
-
-int main()
-{
-  set_mode(VGA_256_COLOR_MODE);       /* set the video mode to 256 colors 320 x 200 */
-								 
-  for (int i=0;i<60;i++)
-  	plot_pixel(100+i,100,5);
-
-  for (int i=0;i<60;i++)
-        plot_pixel(100,100+i,0xA);
-
-  sleep(3);
-  
-  set_mode(TEXT_MODE);                /* set the video mode back to text mode. */
-
-  return 0;
+    while (event_wait_timeout(&e, -1)) {
+        switch (e.type) {
+        case EVT_MOUSEDOWN:
+            c += 2;
+            break;
+        case EVT_MOUSEUP:
+            c--;
+            break;
+        case EVT_MOUSEMOVE:
+            if (VGA)
+                vga_drawpixel(e.x, e.y, c);
+             else pal_drawpixel(e.x, e.y, c);
+            break;
+        case EVT_KEYCHAR:
+            if (e.keychar == 'c') {
+                if (VGA)
+                    vga_fill_rect(0, 0, SCREENWIDTH-1, SCREENHEIGHT-1, 0);
+               else pal_fill_rect(0, 0, SCREENWIDTH-1, SCREENHEIGHT-1, 0);
+            }
+            break;
+        }
+    }
+    graphics_close();
+    event_close();
+    return 0;
 }


### PR DESCRIPTION
Adds graphics and event framework to examples/ directory for building both VGA 640x480 16-color and EGA 320x200 256-color (palette) mode graphics on C86. Builds on host and ELKS.

A new event generation system is in event.c/event.h which handles keyboard and mouse input which is easily integrated with the new graphics functions. Microsoft (QEMU), PC/Logitch and PS/2 mice decoding is supported. The framework is started with `event_open()` and stopped with `event_close()`. A sample program evtest.c shows how to use it. Keyboard input, mouse up/down/move and mouse wheel are supported.

A very fast assembly language driver for VGA 4-plane/16 color (mode 12h) is in vga-4bp.s using vga\_ functions. In addition, 320x200 8bpp/256 color is also supported via pal\_ functions. The modes are easily entered using `graphics_open(mode)` to start and `graphics_close` to exit.

The vgatest program has been rewritten to support both 640x480 and 320x200 graphics modes, and is integrated with the even handling system to produce a very basic paint program that just draws dots on the screen following the mouse (see below). Typing 'c' clears the screen. Pressing the mouse button changes the color.

Here's vgatest in QEMU:
https://github.com/user-attachments/assets/3de73093-4dd4-4895-be00-670d4c1d4c38

The entire system can be built on ELKS using the attached hd32-minix.img: `cd /usr/src; make`.
[hd32-minix.img.zip](https://github.com/user-attachments/files/18631373/hd32-minix.img.zip)

Watching this all compile and run using C86, I must say we have a very capable C compiler (and now graphics) on ELKS :)