### PR TITLE
Fix C86 bad code generation on char (8-bit) assignments

### DIFF
--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -2329,8 +2329,8 @@ common:
 				mk_high (ap1));
 		    } else {
 			ap3 = data_register ();
-			g_code (op_mov, IL2, ap1, ap3);
-			g_code (op_mov, IL2, ap3, ap2);
+			g_code (op_mov, (ILEN) size, ap1, ap3); /* ghaerr fix byte mov */
+			g_code (op_mov, (ILEN) size, ap3, ap2); /* ghaerr fix byte mov */
 			freeop (ap3);
 			freeop (ap2);
 			freeop (ap1);

--- a/compiler/outx86_as86.c
+++ b/compiler/outx86_as86.c
@@ -418,7 +418,7 @@ static void putconst P1 (const EXPR *, ep)
     switch (ep->nodetype) {
     case en_autocon:
     case en_icon:
-	oprintf (ep->v.i >= 0L ? "%ld" : "(%ld)", ep->v.i);
+	oprintf (ep->v.i >= 0L ? "%ld" : " %ld", ep->v.i);
 	break;
     case en_labcon:
 	oprintf ("%s%u", prefix, (unsigned) ep->v.l);
@@ -498,16 +498,16 @@ static void putamode P3 (const ADDRESS *, ap, ILEN, len, unsigned int, sa)
     if (sa & SPN) {
 	switch (len) {		/* kludge for movsx and movzx   */
 	case IL1:
-	    oprintf (" byte ");
+	    oprintf ("byte ");
 	    break;
 	case IL2:
-	    //oprintf (" word ");
+	    //oprintf ("word ");
 	    break;
 	case IL4:
-	    oprintf (" dword ");
+	    oprintf ("dword ");
 	    break;
 	case IL8:
-	    oprintf (" qword ");
+	    oprintf ("qword ");
 	    break;
 	default:
 	    break;

--- a/examples/mouse.c
+++ b/examples/mouse.c
@@ -78,6 +78,7 @@ static int      parseMS(int);       /* routine to interpret MS mouse */
  */
 int open_mouse(void)
 {
+    char *port;
     struct termios termios;
 
     /* set button bits and parse procedure*/
@@ -96,9 +97,12 @@ int open_mouse(void)
 #endif
 
     /* open mouse port*/
-    mouse_fd = open(MOUSE_DEVICE, O_RDWR | O_EXCL | O_NOCTTY | O_NONBLOCK);
+    if (!(port = getenv("MOUSE_PORT")))
+        port = MOUSE_DEVICE;
+    printf("Opening mouse on %s\n", port);
+    mouse_fd = open(port, O_RDWR | O_EXCL | O_NOCTTY | O_NONBLOCK);
     if (mouse_fd < 0) {
-        printf("Can't open mouse %s, error %d\n", MOUSE_DEVICE, errno);
+        printf("Can't open mouse %s, error %d\n", port, errno);
         return -1;
     }
 


### PR DESCRIPTION
Fixes C86 compiler bug identified in #49.

8-bit char or unsigned char assignments should now generate proper code; previously certain assignments always assumed 16-bits incorrectly in the X86 code generator. Tested by examining strcmp.c source and recompilation of entire C86 C library and running dev86 make.

Also cosmetically cleans up generated ASM code previously using parenthesis around BP offsets (e.g. (-4)[bp]) which was required for double-negative '-' character next to each other. Adding a space and removing parenthesis makes AS86 output easier to read. Same was applied to "byte" modifier for output ASM.

During testing `evtest` with the C86 bug fix, the examples/mouse.c driver was updated to allow specifying the mouse port via the MOUSE_PORT environ variable, matching Nano-X's driver. (The enhanced QEMU behavior for Nano-X now requires the mouse to be at /dev/ttyS1 so that error messages can be written to /dev/console or the Terminal window). Thus, when running in QEMU, the MOUSE_PORT=/dev/ttyS1 line should be uncommented.