### PR TITLE
Fix C86 register push assert on left/right shift requirement

### DIFF
--- a/compiler/regx86.c
+++ b/compiler/regx86.c
@@ -150,8 +150,9 @@ static void g_push P2 (REG, reg, DEEP, depth)
     sync_stack ();
     ap = mk_reg (reg);
     switch (reg_alloc[depth].regtype) {
-    case D_REG | T_REG:
     case A_REG | T_REG:
+    case D_REG | T_REG:
+    case D_REG | T_REG | N_REG: /* ghaerr fix shift expression bug by allowing no CX */
     case X_REG | T_REG:
 	g_code (op_push, small_option ? IL2 : IL4, ap, NIL_ADDRESS);
 	break;
@@ -214,6 +215,7 @@ static void g_pop P2 (REG, reg, DEEP, depth)
     switch (reg_alloc[depth].regtype) {
     case A_REG | T_REG:
     case D_REG | T_REG:
+    case D_REG | T_REG | N_REG: /* ghaerr fix shift expression bug by allowing no CX */
     case X_REG | T_REG:
 	g_code (op_pop, small_option ? IL2 : IL4, ap, NIL_ADDRESS);
 	break;


### PR DESCRIPTION
Fixes internal C86 assert() failure when DX register push required with CX register restricted. This occurs during complex left or right shift operations where CX is required on x86. 

Fixes #50.

Assert could fail again when AX register push is required, but will wait until code example seen before fixing without test program.