### PR TITLE
Fix C86 bug when long expressions are used to index arrays

### DIFF
--- a/compiler/genicode.c
+++ b/compiler/genicode.c
@@ -39,7 +39,7 @@
 
 /********************************************************* Macro Definitions */
 
-#define	INDENTATION	2	/* number of columns to indent */
+#define	INDENTATION	4	/* number of columns to indent */
 
 /*********************************************** Static Function Definitions */
 

--- a/compiler/outx86_as86.c
+++ b/compiler/outx86_as86.c
@@ -563,6 +563,9 @@ static void putamode P3 (const ADDRESS *, ap, ILEN, len, unsigned int, sa)
 	    putconst (ap->u.offset);
 	}
 	break;
+    case am_mreg:
+        /* ghaerr: FIXME temp fix for am_mreg not resolved in gen86.c (long indices) */
+        eprintf("WARNING: am_mreg using preg %d not sreg %d\n", ap->preg, ap->sreg);
     case am_dreg:
     case am_areg:
 	reg = ap->preg;

--- a/ecc
+++ b/ecc
@@ -47,6 +47,7 @@ CFLAGS="\
     -stackopt=minimum           \
     -peep=all                   \
     -stackcheck=no              \
+    -icode                      \
     "
 
 ASFLAGS="\


### PR DESCRIPTION
Fixes #47.

This turned out to be complicated - am_mreg (multiple register mode, as opposed to single register modes am_areg or am_dreg) is being used to potentially store a long array index, but the am_mreg is not resolved to am_dreg or am_areg in gen86.c as it should, even when g_cast() internals seems to be doing its job. The putamode() AS86 output routine is being called with am_mreg mode and the AS86 output case for that was not being handled.

For the time being, the (temp?) fix is to use the first of the am_mreg registers and output the AS86 code as am_areg/am_dreg. This should work fine since it appears the mode seems only to be used in conjunction with the internal cast operation, which then doesn't need a second register anyways.

Because I'm not completely certain this won't generate bad code in other so-far untested cases, a WARNING is output to stderr when this occurs. This will then allow the user to see something amiss. In the meantime, code generation is fixed for the case described in #47.

In order to debug this and see what the compiler is doing, I temporarily turned on the ICODE option that displays the expression parse trees when -iconv is passed to c86. The command line option is left in `ecc` but ICODE is default off for size reasons.