### PR TITLE
Proper fix for C86 internal 32->16 cast for long indices

### DIFF
--- a/compiler/cglbdec.h
+++ b/compiler/cglbdec.h
@@ -145,10 +145,8 @@ extern int warn_option;		/* the current warning message level */
 extern BOOL fpu_option;		/* generate code which contains floating point instructions */
 extern BOOL fpu_return_option;	/* return FP value in FP register */
 
-#ifdef ICODE
 extern BOOL icode_option;	/* generate an icode file */
 
-#endif /* ICODE */
 #ifdef PROBES
 extern BOOL probe_option;	/* generate stack probes on function entry */
 

--- a/compiler/cglbdef.c
+++ b/compiler/cglbdef.c
@@ -184,10 +184,8 @@ int     warn_option = WARNLEVEL_DEFAULT;	/* the current warning message level */
 BOOL    fpu_option = FALSE;	/* generate code which contains floating point instructions */
 BOOL    fpu_return_option = FALSE;	/* return FP value in FP register */
 
-#ifdef ICODE
 BOOL    icode_option = FALSE;	/* generate an icode file */
 
-#endif /* ICODE */
 #ifdef PROBES
 BOOL    probe_option = FALSE;	/* generate stack probes on function entry */
 

--- a/compiler/cmain.c
+++ b/compiler/cmain.c
@@ -159,13 +159,11 @@ static OPTION opts[] = {
      {&yesnoopts[0]}	    /*lint !e708*/  /* union initialization */
      },
 #endif /* FORMAT_CHECK */
-#ifdef ICODE
     {
      (const CHAR *) "icode", uniq_option,
      {&icode_option},	    /*lint !e708*/  /* union initialization */
      {NULL}		    /*lint !e708*/  /* union initialization */
      },
-#endif /* ICODE */
 #ifdef DOINLINE
     {
      (const CHAR *) "inline=", numeric_option,

--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -2787,15 +2787,15 @@ static ADDRESS *g_cast P4 (ADDRESS *, ap, TYP *, tp1, TYP *, tp2, FLAGS,
 	case bt_uint32:
 	case bt_ulong:
 	case bt_pointer32:
-	    ap1 = mk_legal (ap, flags, tp2);
-	    freeop (ap1);
-	    if ((ap1->mode == am_mreg) && (ap1->preg == EAX)) {
+            /* ghaerr rewrite 32->16 cast to eliminate putamode(am_mreg) (long index) */
+	    freeop (ap);
+	    if ((ap->mode == am_mreg) && (ap->preg == EAX)) {
 		ap = ax_register ();
-	    } else {
-		ap = data_register ();
-		g_code (op_mov, IL2, mk_low (ap1), ap);
+		return mk_legal (ap, flags, tp2);
 	    }
-	    return mk_legal (ap, flags, tp2);
+	    ap1 = data_register ();
+	    g_code (op_mov, IL2, mk_low (ap), ap1);
+	    return mk_legal (ap1, flags, tp2);
 #ifdef FLOAT_IEEE
 	case bt_float:
 	case bt_double:

--- a/compiler/genicode.c
+++ b/compiler/genicode.c
@@ -97,9 +97,9 @@ static void type P1 (const TYP *, tp)
     case bt_pointer16:
     case bt_pointer32:
 	if (is_array_type (tp)) {
-	    iprintf ("array of ");
+	    iprintf ("array of");
 	} else {
-	    iprintf ("pointer to ");
+	    iprintf ("pointer to");
 	}
 	type (referenced_type (tp));
 	break;
@@ -116,7 +116,7 @@ static void type P1 (const TYP *, tp)
 	iprintf ("union ");
 	break;
     case bt_func:
-	iprintf ("function returning ");
+	iprintf ("function returning");
 	type (returned_type (tp));
 	break;
     case bt_longdouble:

--- a/compiler/outx86_as86.c
+++ b/compiler/outx86_as86.c
@@ -563,9 +563,6 @@ static void putamode P3 (const ADDRESS *, ap, ILEN, len, unsigned int, sa)
 	    putconst (ap->u.offset);
 	}
 	break;
-    case am_mreg:
-        /* ghaerr: FIXME temp fix for am_mreg not resolved in gen86.c (long indices) */
-        eprintf("WARNING: am_mreg using preg %d not sreg %d\n", ap->preg, ap->sreg);
     case am_dreg:
     case am_areg:
 	reg = ap->preg;


### PR DESCRIPTION
Proper and long term fix for internal cast code when casting 32- to 16-bits, which is used when long values are used to index an array. This fix succeeds #53, originally discussed in #47.

The previous "WARNING" output is removed as it is no longer needed.

Also allows use of C86 -icode option without complaining, even if ICODE is not defined in config.h; this is for easier debugging with `ecc` which specifies -icode. Only config.h define ICODE needs to be changed to enable display of the parse tree.
