### PR TITLE
Rewrite ld86 to support multiple text sections

### DIFF
--- a/as/as.c
+++ b/as/as.c
@@ -129,7 +129,7 @@ PUBLIC void initp1p2()
     lctabtop = (lcptr = lctab = hid_lctab) + NLOC;
     for (lcp = lctab; lcp < lctabtop; ++lcp)
     {
-	lcp->data = lcdata = RELBIT;	/* lc relocatable until 1st ORG */
+	lcp->data = lcdata = TEXTLOC | RELBIT;	/* lc relocatable until 1st ORG */
 	lcp->lc = lc = 0;
     }
 }

--- a/as/const.h
+++ b/as/const.h
@@ -308,11 +308,9 @@ oops - ENTBIT misplaced
 
 /* special segments */
 
-#define BSSLOC		3
-#define DATALOC		3
-#define DPLOC		2
-#define STRLOC		1
-#define TEXTLOC		0
+#define BSSLOC		7
+#define DATALOC		7	/* ld86 data sections 4..7 */
+#define TEXTLOC		3	/* ld86 text sections 0..3 */
 
 #include "errors.h"
 

--- a/as/genobj.c
+++ b/as/genobj.c
@@ -572,7 +572,7 @@ PUBLIC void objheader()
 	}
 	putobj1(0);
     }
-    putobj1(OBJ_SET_SEG | 0);	/* default segment 0, |0010|SEGM| */
+    putobj1(OBJ_SET_SEG | TEXTLOC);	/* default .text segment, |0010|SEGM| */
 }
 
 /* write trailer to object file */

--- a/as/pops.c
+++ b/as/pops.c
@@ -417,6 +417,7 @@ pfv func;
     }
 }
 
+#if UNUSED
 PUBLIC void fatalerror(err_str)
 char * err_str;
 {
@@ -425,6 +426,7 @@ char * err_str;
     listline();
     finishup();
 }
+#endif
 
 /* swap position with label position, do error, put back posn */
 /* also clear label ptr */

--- a/as/typeconv.c
+++ b/as/typeconv.c
@@ -10,8 +10,11 @@
 #include "type.h"
 #include "globvar.h"
 
-void xxerr P((char *));
-void xxerr(x) char * x; { write(2, x, strlen(x)); }
+static void errexit(char *str)
+{
+    write(2, str, strlen(str));
+    exit(1);
+}
 
 static int long_off[4] = {0,1,2,3};
 static int int_off[2] = {0,1};
@@ -90,7 +93,7 @@ unsigned count;
 	u4c4(buf, (u4_t) offset);
 	return;
     default:
-        xxerr("WARNING: typeconv.c(u4cn) illegal count\n");
+        errexit("u4cn error");
 	return;
     }
 }
@@ -112,7 +115,7 @@ unsigned count;
 	u4c4(buf, (u4_t) offset);
 	return;
     default:
-        xxerr("WARNING: typeconv.c(u2cn) illegal count\n");
+        errexit("u2cn error");
 	return;
     }
 }
@@ -162,7 +165,7 @@ unsigned count;
     case 4:
 	return c4u4(buf);
     default:
-        xxerr("WARNING: typeconv.c(cnu4) illegal count\n");
+        errexit("cnu4 error");
 	return 0;
     }
 }
@@ -182,7 +185,7 @@ unsigned count;
     case 4:
 	return (u2_pt) c4u4(buf);
     default:
-        xxerr("WARNING: typeconv.c(cnu2) illegal count\n");
+        errexit("cnu2 error");
 	return 0;
     }
 }

--- a/ld/config.h
+++ b/ld/config.h
@@ -17,7 +17,7 @@
 
 #undef HOST_8BIT		/* enable some 8-bit optimizations */
 
-#ifndef __AS386_16__
+#if !ELKS
 #define S_ALIGNMENT	4	/* source memory alignment, power of 2 */
 				/* don't use for 8 bit processors */
 				/* don't use even for 80386 - overhead for */
@@ -28,6 +28,7 @@
 #ifdef I80386
 #define LONG_OFFSETS
 #endif
+#define COMM_ALIGN      2       /* .comm variable alignment for 8086 */
 
 /* these must be defined to suit the source libraries */
 

--- a/ld/io.c
+++ b/ld/io.c
@@ -48,7 +48,6 @@ PRIVATE unsigned warncount;	/* count of warnings */
 #define off_t	long		/* NOT a typedef */
 #endif
 
-FORWARD void errexit P((char *message));
 FORWARD void flushout P((void));
 #ifdef REL_OUTPUT
 FORWARD void flushtrel P((void));
@@ -465,7 +464,7 @@ unsigned count;
 
 /* error module */
 
-PRIVATE void errexit(message)
+PUBLIC void errexit(message)
 char *message;
 {
     putstrn(message);

--- a/ld/objdump86.c
+++ b/ld/objdump86.c
@@ -325,10 +325,10 @@ char * archive;
             printf("OBJECTSECTION %d\n", modno);
 	 if( read_sectheader() < 0 ) break;
 
-	 /* segments 0, 4-E are text, 1-3 are data*/
+	 /* segments 0-3 and 8-14 are text, 4-7 are data*/
 	 for(i=0; i<16; i++)
 	 {
-	    if(i < 1 || i > 4)
+	    if(i <= 3 || i >= 8)
 		 size_text += segsizes[i];
 	    else size_data += segsizes[i];
 	 }

--- a/ld/type.h
+++ b/ld/type.h
@@ -108,6 +108,7 @@ void writedrel P((char *buf, unsigned count));
 void writeout P((char *buf, unsigned count));
 void writetrel P((char *buf, unsigned count));
 void fatalerror P((char *message));
+void errexit P((char *message));
 void inputerror P((char *message));
 void input1error P((char *message));
 void outofmemory P((void));

--- a/ld/typeconv.c
+++ b/ld/typeconv.c
@@ -10,11 +10,6 @@
 #include "type.h"
 #include "globvar.h"
 
-void xxerr P((char *));
-void xxerr(x) char * x; { write(2, x, strlen(x)); }
-
-static int no_swap   = 1;
-
 static int long_off[4] = {0,1,2,3};
 static int int_off[2] = {0,1};
 
@@ -22,9 +17,10 @@ PUBLIC bool_pt typeconv_init(big_endian, long_big_endian)
 bool_pt big_endian;
 bool_pt long_big_endian;
 {
+#if defined(__AS386_16__) || defined(__ELKS__)
+   //assert(!big_endian && !long_big_endian);
+#else
    int i;
-   no_swap = (!big_endian && !long_big_endian);
-
    for(i=0; i<4; i++) long_off[i] = i;
    for(i=0; i<2; i++) int_off[i] = i;
 
@@ -40,6 +36,7 @@ bool_pt long_big_endian;
 
       i = int_off[0]; int_off[0] = int_off[1]; int_off[1] = i;
    }
+#endif
    return 1;
 }
 
@@ -47,34 +44,30 @@ PUBLIC void u2c2(buf, offset)
 char *buf;
 u2_pt offset;
 {
-#ifdef __AS386_16__
-   if( no_swap )
-   {
+#if defined(__AS386_16__) || defined(__ELKS__)
       *((unsigned short*)buf) = offset;	/* UNALIGNED ACCESS! */
       return;
-   }
-#endif
+#else
    buf[int_off[0]] = offset;
    buf[int_off[1]] = (offset>>8);
+#endif
 }
 
 PUBLIC void u4c4(buf, offset)
 char *buf;
 u4_t offset;
 {
-   int i;
-#ifdef __AS386_16__
-   if( no_swap )
-   {
+#if defined(__AS386_16__) || defined(__ELKS__)
       *((unsigned long*)buf) = offset;	/* UNALIGNED ACCESS! */
       return;
-   }
-#endif
+#else
+   int i;
    for(i=0; i<4; i++)
    {
       buf[long_off[i]] = offset;
       offset >>= 8;
    }
+#endif
 }
 
 PUBLIC void u4cn(buf, offset, count)
@@ -94,7 +87,7 @@ unsigned count;
 	u4c4(buf, (u4_t) offset);
 	return;
     default:
-        xxerr("WARNING: typeconv.c(u4cn) illegal count\n");
+        errexit("u4cn error");
 	return;
     }
 }
@@ -116,7 +109,7 @@ unsigned count;
 	u4c4(buf, (u4_t) offset);
 	return;
     default:
-        xxerr("WARNING: typeconv.c(u2cn) illegal count\n");
+        errexit("u2cn error");
 	return;
     }
 }
@@ -124,30 +117,31 @@ unsigned count;
 PUBLIC u2_pt c2u2(buf)
 char *buf;
 {
+#if defined(__AS386_16__) || defined(__ELKS__)
+   return *((u2_pt *)buf);	/* UNALIGNED ACCESS! */
+#else
     u2_pt res;
-#ifdef __AS386_16__
-   if( no_swap ) return *((u2_pt *)buf);	/* UNALIGNED ACCESS! */
-#endif
-
     res  =   ((unsigned char *)buf) [int_off[0]]
          + ((((unsigned char *)buf) [int_off[1]]) << 8);
     return res;
+#endif
 }
 
 PUBLIC u4_t c4u4(buf)
 char *buf;
 {
+#if defined(__AS386_16__) || defined(__ELKS__)
+   return *((u4_t *)buf);	/* UNALIGNED ACCESS! */
+#else
     u4_t res;
     int i;
-#ifdef __AS386_16__
-   if( no_swap ) return *((u4_t *)buf);		/* UNALIGNED ACCESS! */
-#endif
     res = 0;
     for(i=3; i>=0; i--)
     {
         res = (res<<8) + ((unsigned char *)buf) [long_off[i]];
     }
     return res;
+#endif
 }
 
 PUBLIC u4_t cnu4(buf, count)
@@ -165,7 +159,7 @@ unsigned count;
     case 4:
 	return c4u4(buf);
     default:
-        xxerr("WARNING: typeconv.c(cnu4) illegal count\n");
+        errexit("cnu4 error");
 	return 0;
     }
 }
@@ -185,7 +179,7 @@ unsigned count;
     case 4:
 	return (u2_pt) c4u4(buf);
     default:
-        xxerr("WARNING: typeconv.c(cnu2) illegal count\n");
+        errexit("cnu2 error");
 	return 0;
     }
 }

--- a/ld/writex86.c
+++ b/ld/writex86.c
@@ -306,21 +306,17 @@ bool_pt argxsym;
 		}
 	}
 
-    /* adjust special symbols */
-    int hasdata = 0;
+    /* compute end of data offset and adjust special symbols */
+    edataoffset = bdataoffset;
     for (seg = 0; seg < NSEG; ++seg)
     {
 	/* only count data of nonzero length */
 #ifdef DATASEGS
-	if (segsz[seg] != 0) {
+	if (segsz[seg] != 0 && seg != 0)
 	    edataoffset = segbase[seg] + segsz[seg];
-	    if (seg != 0) hasdata = 1;
-        }
 #else
-	if (segsz[seg] != 0 && seg < 8) {
+	if (segsz[seg] != 0 && seg >= 4 && seg <= 7)
 	    edataoffset = segbase[seg] + segsz[seg];
-	    if (seg >=4 && seg <= 7) hasdata = 1;
-	}
 #endif
 #if UNUSED
 	segboundary[5] = hexdigit[seg];		/* to __segX?H */
@@ -341,8 +337,6 @@ bool_pt argxsym;
 #endif
 #endif
     }
-    if (!hasdata)
-        edataoffset = bdataoffset;              /* fixes zero data length bug */
 #ifdef DATASEGS
     endoffset = combase[NSEG - 1] + comsz[NSEG - 1];
 #else

--- a/ld/writex86.c
+++ b/ld/writex86.c
@@ -80,8 +80,6 @@ PRIVATE unsigned relocsize;	/* current relocation size 1, 2 or 4 */
 PRIVATE bin_off_t segadj[NSEG];	/* adjusts (file offset - seg offset) */
 				/* depends on zero init */
 PRIVATE bin_off_t segbase[NSEG];/* bases of data parts of segments */
-PRIVATE char segboundary[9] = "__seg0DH";
-				/* name of seg boundary __seg0DL to __segfCH */
 PRIVATE bin_off_t segpos[NSEG];	/* segment positions for current module */
 PRIVATE bin_off_t segsz[NSEG];	/* sizes of data parts of segments */
 				/* depends on zero init */
@@ -93,11 +91,10 @@ PRIVATE bool_t xsym;		/* extended symbol table */
 
 FORWARD void linkmod P((struct modstruct *modptr));
 FORWARD void padmod P((struct modstruct *modptr));
-FORWARD void setsym P((char *name, bin_off_t value));
-FORWARD void symres P((char *name));
 FORWARD void setseg P((fastin_pt newseg));
 FORWARD void skip P((unsigned countsize));
 FORWARD void writeheader P((void));
+
 #ifndef VERY_SMALL_MEMORY
 FORWARD void v7header P((void));
 #endif
@@ -105,6 +102,12 @@ FORWARD void v7header P((void));
 FORWARD void cpm86header P((void));
 #endif
 FORWARD void writenulls P((bin_off_t count));
+
+#if UNUSED
+PRIVATE char segboundary[9] = "__seg0DH"; /* name of seg boundary __seg0DL to __segfCH */
+FORWARD void setsym P((char *name, bin_off_t value));
+FORWARD void symres P((char *name));
+#endif
 
 EXTERN bool_t reloc_output;
 
@@ -147,6 +150,7 @@ bool_pt argxsym;
 	    bdataoffset = page_size();
     }
 
+#if UNUSED
     /* reserve special symbols use curseg to pass parameter to symres() */
     for (curseg = 0; curseg < NSEG; ++curseg)
     {
@@ -160,21 +164,22 @@ bool_pt argxsym;
 	segboundary[7] = 'H';
 	symres(segboundary);	/* __segXCH */
 #ifndef DATASEGS
-        if( curseg > 3 )
-	{
+        if (curseg >= 8) {
 	   segboundary[6] = 'S';
 	   segboundary[7] = 'O';
 	   symres(segboundary); /* __segXSO */
         }
 #endif
     }
-    curseg = 3;
+    curseg = 7;
     symres("__edata");
     symres("__end");
     symres("__heap_top");
-    curseg = 0;			/* text seg, s.b. variable */
+    curseg = 3;			/* text seg, s.b. variable */
     symres("__etext");
     symres("__segoff");
+#endif
+    curseg = 0;
 
     /* calculate segment and common sizes (sum over loaded modules) */
     /* use zero init of segsz[] */
@@ -228,33 +233,39 @@ bool_pt argxsym;
 #ifdef DATASEGS
      * Assume seg 0 is text and rest are data
 #else
-     * Assume seg 1..3 are data, Seg 0 is real text, seg 4+ are far text
+     * Assume 0..3 are text, 4..7 are data, seg 8+ are far text
 #endif
      */
     segpos[0] = segbase[0] = spos = btextoffset;
     combase[0] = segbase[0] + segsz[0];
-    segadj[1] = segadj[0] = -btextoffset;
-    etextpadoff = etextoffset = combase[0] + comsz[0];
-    if (sepid)
+    segadj[0] = -btextoffset;
+#ifndef DATASEGS
+    for (seg = 1; seg <= 3; ++seg)
     {
-	etextpadoff = ld_roundup(etextoffset, 0x10, bin_off_t);
-	segadj[1] += etextpadoff - bdataoffset;
+	segpos[seg] = segbase[seg] = combase[seg - 1] + comsz[seg - 1];
+	combase[seg] = segbase[seg] + segsz[seg];
+	segadj[seg] = segadj[seg - 1];
     }
+#endif
+    etextpadoff = etextoffset = combase[3] + comsz[3];
+    if (sepid)
+	etextpadoff = ld_roundup(etextpadoff, 0x10, bin_off_t);
     else if (bdataoffset == 0)
 	bdataoffset = etextpadoff;
-    segpos[1] = segbase[1] = edataoffset = bdataoffset;
-    combase[1] = segbase[1] + segsz[1];
+    segpos[4] = segbase[4] = edataoffset = bdataoffset;
+    combase[4] = segbase[4] + segsz[4];
+    segadj[4] = etextpadoff;
 #ifndef DATASEGS
-    for (seg = 4; seg < NSEG; ++seg)
+    for (seg = 8; seg < NSEG; ++seg)
     {
 	segpos[seg] = segbase[seg] = 0;
 	combase[seg] = segbase[seg] + segsz[seg];
 	segadj[seg] = etextpadoff;
 
 	etextpadoff += ld_roundup(segsz[seg] + comsz[seg], 0x10, bin_off_t);
-	segadj[1]   += ld_roundup(segsz[seg] + comsz[seg], 0x10, bin_off_t);
+	segadj[4]   += ld_roundup(segsz[seg] + comsz[seg], 0x10, bin_off_t);
     }
-    for (seg = 2; seg < 4; ++seg)
+    for (seg = 5; seg <= 7; ++seg)
 #else
     for (seg = 2; seg < NSEG; ++seg)
 #endif
@@ -307,43 +318,49 @@ bool_pt argxsym;
 	    if (seg != 0) hasdata = 1;
         }
 #else
-	if (segsz[seg] != 0 && seg < 4) {
+	if (segsz[seg] != 0 && seg < 8) {
 	    edataoffset = segbase[seg] + segsz[seg];
-	    if (seg != 0) hasdata = 1;
+	    if (seg >=4 && seg <= 7) hasdata = 1;
 	}
 #endif
+#if UNUSED
 	segboundary[5] = hexdigit[seg];		/* to __segX?H */
 	segboundary[6] = 'D';
-	setsym(segboundary, (tempoffset = segbase[seg]) + segsz[seg]);
-						/* __segXDH */
+	setsym(segboundary, (tempoffset = segbase[seg]) + segsz[seg]); /* __segXDH */
 	segboundary[7] = 'L';
-	setsym(segboundary, tempoffset);	/* __segXDL */
+	setsym(segboundary, tempoffset);			/* __segXDL */
 	segboundary[6] = 'C';
-	setsym(segboundary, tempoffset = combase[seg]);
-						/* __segXCL */
+	setsym(segboundary, tempoffset = combase[seg]);		/* __segXCL */
 	segboundary[7] = 'H';
-	setsym(segboundary, tempoffset + comsz[seg]);
-						/* __segXCH */
+	setsym(segboundary, tempoffset + comsz[seg]);		/* __segXCH */
 #ifndef DATASEGS
-        if( seg > 3 )
-	{
+        if (seg >= 8) {
 	   segboundary[6] = 'S';
 	   segboundary[7] = 'O';
-	   setsym(segboundary, (bin_off_t)(segadj[seg]-segadj[0])/0x10);
-	   /* __segXSO */
+	   setsym(segboundary, (bin_off_t)(segadj[seg]-segadj[0])/0x10); /* __segXSO */
         }
+#endif
 #endif
     }
     if (!hasdata)
         edataoffset = bdataoffset;              /* fixes zero data length bug */
+
+#if UNUSED
     setsym("__etext", etextoffset);
     setsym("__edata", edataoffset);
 #ifdef DATASEGS
     setsym("__end", endoffset = combase[NSEG - 1] + comsz[NSEG - 1]);
 #else
-    setsym("__end", endoffset = combase[3] + comsz[3]);
+    setsym("__end", endoffset = combase[7] + comsz[7]);
 #endif
-    setsym("__segoff", (bin_off_t)(segadj[1]-segadj[0])/0x10);
+    setsym("__segoff", (bin_off_t)(segadj[4]-segadj[0])/0x10);
+
+    //if( heap_top_value < 0x100 || endoffset > heap_top_value-0x100)
+       //heap_top_value = endoffset + 0x8000;
+    if( heap_top_value > 0x10000 && !bits32 ) heap_top_value = 0x10000;
+    setsym("__heap_top", (bin_off_t)heap_top_value);
+#endif
+
     if( !bits32 )
     {
         if( etextoffset > 65536L )
@@ -351,11 +368,6 @@ bool_pt argxsym;
         if( endoffset > 65536L )
             fatalerror("data segment too large for 16bit");
     }
-
-    //if( heap_top_value < 0x100 || endoffset > heap_top_value-0x100)
-       //heap_top_value = endoffset + 0x8000;
-    if( heap_top_value > 0x10000 && !bits32 ) heap_top_value = 0x10000;
-    setsym("__heap_top", (bin_off_t)heap_top_value);
 
     openout(outfilename);
 #ifndef MSDOS
@@ -415,8 +427,7 @@ bool_pt argxsym;
 			    extsym.n_sclass = C_EXT;
 			else
 			    extsym.n_sclass = C_STAT;
-			if (!(flags & I_MASK) ||
-			     flags & C_MASK)
+			if (!(flags & I_MASK) || flags & C_MASK)
 			    switch (flags & (A_MASK | SEGM_MASK))
 			    {
 #ifdef DATASEGS
@@ -430,8 +441,14 @@ bool_pt argxsym;
 #ifdef DATASEGS
 			    default:
 #else
-			    case 1: case 2: case 3:
-			    case A_MASK|1: case A_MASK|2: case A_MASK|3:
+			    case 4:
+			    case 5:
+			    case 6:
+			    case 7:
+			    case A_MASK|4:
+			    case A_MASK|5:
+			    case A_MASK|6:
+			    case A_MASK|7:
 #endif
 				if (flags & (C_MASK | SA_MASK))
 				    extsym.n_sclass |= N_BSS;
@@ -446,8 +463,7 @@ bool_pt argxsym;
 			{
 			   int i;
 			   extsym.n_sclass = 0;
-			   memset((void*)&extsym.n_value,0,
-				   sizeof(extsym.n_value));
+			   memset((void*)&extsym.n_value,0, sizeof(extsym.n_value));
 
 			   for(i=sizeof extsym.n_name; i<strlen(symptr->name);
 			       i+=sizeof extsym.n_name)
@@ -600,6 +616,7 @@ struct modstruct *modptr;
     }
 }
 
+#if UNUSED
 PRIVATE void setsym(name, value)
 char *name;
 bin_off_t value;
@@ -624,6 +641,7 @@ register char *name;
 	symptr->flags = E_MASK | curseg;	/* show defined, not common */
     }
 }
+#endif
 
 /* set new segment */
 
@@ -694,9 +712,9 @@ PRIVATE void writeheader()
             sizeof header.a_entry);
     offtocn((char *) &header.a_version, (bin_off_t) 1,
 	    sizeof header.a_version);
-    offtocn((char *) &header.a_total, (bin_off_t) heap_top_value,
+    u2cn((char *) &header.a_total, (unsigned short) heap_top_value,
 	    sizeof header.a_total);
-    offtocn((char *) &header.a_minstack, (bin_off_t) stack_value,
+    u2cn((char *) &header.a_minstack, (unsigned short) stack_value,
 	    sizeof header.a_minstack);
     if( FILEHEADERLENGTH )
        writeout((char *) &header, FILEHEADERLENGTH);
@@ -757,5 +775,5 @@ bin_off_t count;
     if( lcount < 0 )
     	fatalerror("org command requires reverse seek");
     while (count-- > 0)
-	writechar(curseg == 0? 0x90: 0);    /* NOTE doesn't yet write NOPs in far text */
+	writechar((curseg <= 3 || curseg >= 8)? 0x90: 0);
 }


### PR DESCRIPTION
Enhances ld86 to support multiple text sections (numbered 0 - 3, instead of just 0). This allows ld86 to operate much like modern linkers by allowing special segments to be linked before .text/.data to implement things like not allowing .text function to link at location 0, implement constructors/destructors, and other cool features automatically under the hood.

This allows the removal of the "zero() function" kluge required by https://github.com/ghaerr/elks/pull/2227 for `signal` to work properly.

This change requires all files to be recompiled from .c -> .o and relinked, as the toolchain is becoming incompatible with the previous as86/ld86 from dev86. Previously, .text was section 0 and data sections were 1-3 with .data 3. Now, text sections are 0-3, data sections 4-7, with .text being section 3 and .data section 7. The linker works by always ordering text sections in numeric order, followed by data sections.

All of this is pretty technical, but this portion of the startup code in c86/syscall.s shows how the address 0 of the text section starts with four NOPs, regardless of which order the startup object module is linked in:
```
        .sect   0               ; first text seg
        nop                     ; prevent text having address 0 for SIG_DFL,SIG_IGN
        nop
        nop
        nop
        .sect   4               ; first data seg
        dw      0,0             ; prevent data having address 0
        .data                   ; default data seg 7
        .text                   ; default text seg 3
```
This then requires the linker to link section 0 before "user code" using section 3 (.text). Here's a screenshot showing the disassembly using `disasm86` of the testsig.c program fragment
```
void catch(int sig)
{
    printf("GOT %d\n", sig);
    signal(SIGINT, catch);
}

int main(int ac, char **av)
{
```
with `catch` now offset 4 bytes into the final text segment:
<img width="832" alt="ld86 sect 0" src="https://github.com/user-attachments/assets/4768e600-07a1-4e81-a255-83bab0474a51" />

While deep into ld86, the following other enhancements were made:
- Change default .comm alignment to 2 from 4, usually saving a couple bytes unused space between variables after link.
- Replacing code reading short/longs from the input object file with much faster routines.
- Removing 4-byte alignment for internal symbol table structure members.
- Removing unused code setting linker symbols not used in programs (\_\_end, etc).
- Some code cleanup.

Because of this change, AS86 segment number is now different for 8086-toolchain and ELKS from the older dev86 section numbering. This means `objdump86` may not compute the proper data/text sizes for those object files, although it is highly doubtful one will ever encounter any of them. In a future PR, the duplicate copy of `objdump86` will be removed as well.

