### PR TITLE
Remove K&R warning about parameter size changed by prototype unless K&R

### DIFF
--- a/compiler/expr.c
+++ b/compiler/expr.c
@@ -1467,7 +1467,7 @@ static EXPR *parmlist P2 (const EXPR *, ep, const BLOCK *, block)
 		tp2 = tp_pointer;
 	    }
 #ifndef SYNTAX_CORRECT
-	    if (!is_same_size (tp, tp2)) {
+	    if (lang_option == LANG_KANDR && !is_same_size (tp, tp2)) {
 		message (WARN_PARAMSIZE, pnum, fname);
 	    }
 #endif /* SYNTAX_CORRECT */

--- a/cpp/cpp.c
+++ b/cpp/cpp.c
@@ -1255,7 +1255,7 @@ void gen_substrings(char *macname, char *data_str, int arg_count, int is_vararg)
    (void)macname;
 
    len = sizeof(struct arg_store) * arg_count;
-   if (len == 0) len = 1;
+   if (len == 0) len = 1;       /* fix for ELKS libc where malloc(0) returns NULL */
    arg_list = malloc(len);
    if(!arg_list) cfatal("Out of memory for arglist");
    memset(arg_list, 0, len);

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,9 @@ work on any recent Linux or MacOS with OpenWatcom v2 installed (source the OW ow
 OpenWatcom environment variables and env.sh from ELKS, or just env.sh from ELKS and wcenv.sh in libc directory of 
 ELKS top-dir, after adjusting the path to OpenWatcom directory).
 
-ELKS source code top directory contains a script 'buildc86.sh' whcih builds the
+The ELKS source code top directory contains a script 'buildc86.sh' which builds the
 toolchain binaries, and 'copyc86.sh' which copies the toolchain binaries, headers and
-library to ELKS /usr and also produces an archive.
+library to ELKS /usr, as well as an archive 'devc86.tar'.
 
 ## Build and Install
 

--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,9 @@ work on any recent Linux or MacOS with OpenWatcom v2 installed (source the OW ow
 OpenWatcom environment variables and env.sh from ELKS, or just env.sh from ELKS and wcenv.sh in libc directory of 
 ELKS top-dir, after adjusting the path to OpenWatcom directory).
 
-ELKS source code top directory contains a script called 'copyc86.sh' which copies the toolchain binaries, headers and library to ELKS root fs template and also produces
-an archive.
+ELKS source code top directory contains a script 'buildc86.sh' whcih builds the
+toolchain binaries, and 'copyc86.sh' which copies the toolchain binaries, headers and
+library to ELKS /usr and also produces an archive.
 
 ## Build and Install
 


### PR DESCRIPTION
While looking through some of @rafael2k's code in his elks-viewer project, I noticed that the 2nd parameter to 
`fseek(fp, 0L, SEEK_END)` had been changed to a long, presumably to remove the C86 message "Warning: size of parameter 2 changed by function prototype".

Looking at the C86 source showed this warning was designed for K&R source, where such a change matters. This PR removes the warning unless K&R is set using -lang=kandr.

Also includes small cleanups.