### PR TITLE
Fix C86 sign/zero-extend char to long bug

### DIFF
--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -994,7 +994,8 @@ static ADDRESS *g_extend P3 (ADDRESS *, ap, TYP *, tp1, TYP *, tp2)
 		g_code (op_shl, IL2, mk_immed (8L), mk_low (ap));
 		g_code (op_shr, IL2, mk_immed (8L), mk_low (ap));
 	    } else {
-		g_code (op_and, IL2, mk_immed (0xFF00L), mk_low (ap));
+		/* ghaerr: fix sign/zero-extend unsigned char to long bug */
+		g_code (op_and, IL2, mk_immed (0x00FFL), mk_low (ap));
 	    }
 	    /*lint -fallthrough */
 	case bt_uint16:


### PR DESCRIPTION
Fixes #64.

Kind of unbelievable this bug's been in there forever; there's no question more testing needs to be done on char-to-long conversions, given this.

Tested by building devkit and everything still compiles and runs.