### PR TITLE
Add __loadreg builtin to arbitrarily load specified register w/r-value

### DIFF
--- a/compiler/cglbdec.h
+++ b/compiler/cglbdec.h
@@ -243,6 +243,7 @@ extern const CHAR *fscanf_name;	/* pointer to the name fscanf */
 extern const CHAR *sscanf_name;	/* pointer to the name sscanf */
 extern const CHAR *func_name;	/* pointer to the name __func__ */
 extern const CHAR *main_name;	/* pointer to the name main */
+extern const CHAR *loadreg_name;	/* pointer to the name __loadreg */
 
 extern struct slit *strtab;	/* table of strings to be output to the assembler file */
 extern BOOL uses_structassign;	/* function uses a structure assignment */

--- a/compiler/cglbdef.c
+++ b/compiler/cglbdef.c
@@ -129,7 +129,7 @@ BOOL    listing_option = FALSE;	/* list the input source and symbol tables */
 
 #endif /* LIST */
 BOOL    longdouble_option = FALSE;	/* long doubles are to be the same size as doubles */
-BOOL    obsolete_option = TRUE;	/* future language directions defined obsolete feature */
+BOOL    obsolete_option = FALSE;	/* future language directions defined obsolete feature */
 BOOL    opt_option = TRUE;	/* use the global optimiser */
 BOOL    optimize_option = FALSE;	/* do "expensive" optimisations */
 

--- a/compiler/cglbdef.c
+++ b/compiler/cglbdef.c
@@ -91,10 +91,9 @@ BOOL    align_option = FALSE;	/* align structure fields to smallest alignment */
 
 #endif /* INTEL */
 #ifdef ASM
-//BOOL    asm_option = FALSE;	/* asm keyword allowed */
-BOOL    asm_option = TRUE;	// -WSF
-
+BOOL    asm_option = TRUE;	/* asm keyword allowed */
 #endif /* ASM */
+
 BOOL    bitfield_option = FALSE;	/* reverse allocation order of bitfields */
 BOOL    code_option = TRUE;	/* generate code */
 int     datamodel_option = 0;	/* method of referencing global data */
@@ -130,7 +129,7 @@ BOOL    listing_option = FALSE;	/* list the input source and symbol tables */
 
 #endif /* LIST */
 BOOL    longdouble_option = FALSE;	/* long doubles are to be the same size as doubles */
-BOOL    obsolete_option = FALSE;	/* future language directions defined obsolete feature */
+BOOL    obsolete_option = TRUE;	/* future language directions defined obsolete feature */
 BOOL    opt_option = TRUE;	/* use the global optimiser */
 BOOL    optimize_option = FALSE;	/* do "expensive" optimisations */
 
@@ -299,6 +298,7 @@ const CHAR *fscanf_name;	/* pointer to the name fscanf */
 const CHAR *sscanf_name;	/* pointer to the name sscanf */
 const CHAR *func_name;		/* pointer to the name __func__ */
 const CHAR *main_name;		/* pointer to the name main */
+const CHAR *loadreg_name;	/* pointer to the name __loadreg */
 
 STRING *strtab;			/* table of strings to be output to the assembler file */
 BOOL    uses_structassign;	/* function uses a structure assignment */

--- a/compiler/chdr.h
+++ b/compiler/chdr.h
@@ -786,8 +786,10 @@ struct options
 #define	DEBUG_LONGLONG	7	/* debugging the long long support */
 #define	is_debugging(x)	((unsigned)internal_option & (1U<<x))
 #define	DPRINTF(x)	debugprintf x
+#define debug           printf
 #else /* DEBUG */
 #define	DPRINTF(x)
+#define debug(...)
 #endif /* DEBUG */
 /*
  *   Language options

--- a/compiler/expr.c
+++ b/compiler/expr.c
@@ -1497,6 +1497,21 @@ static EXPR *parmlist P2 (const EXPR *, ep, const BLOCK *, block)
 }
 
 /*
+ * check builtin function parameters
+ */
+static void check_builtin P2 (EXPR *, ep, EXPR *, parms)
+{
+    EXPR *ep1;
+
+    if (ep->v.p[0]->v.str == loadreg_name) {
+	parms = parms->v.p[1];  /* param 2 */
+	ep1 = parms->v.p[0];	/* register */
+	if (!is_icon (ep1))
+	    message (ERR_CONSTINT);
+    }
+}
+
+/*
  * primary will parse a primary expression and set the node pointer returning
  * the type of the expression parsed. primary expressions are any of:
  * id
@@ -1795,6 +1810,7 @@ static EXPR *primary P0 (void)
 		switch (funckind (tp1))
 		{
 		case fc_normal:
+		    check_builtin(ep, ep2);
 		    ep = mk_node (en_fcall, ep, ep2, tp);
 		    break;
 		case fc_user:

--- a/compiler/gen386.c
+++ b/compiler/gen386.c
@@ -94,9 +94,9 @@ static ADDRESS edx_reg = {
 };
 
 static REGTYPE reg_type[] = {
-    (REGTYPE) (D_REG | A_REG | X_REG | T_REG),	/* EAX */
-    (REGTYPE) (D_REG | A_REG | X_REG | T_REG),	/* EDX */
-    (REGTYPE) (D_REG | A_REG | Y_REG | T_REG | C_REG),	/* ECX */
+    (REGTYPE) (D_REG | A_REG | X_REG | T_REG | AX_REG), /* EAX */
+    (REGTYPE) (D_REG | A_REG | X_REG | T_REG | DX_REG), /* EDX */
+    (REGTYPE) (D_REG | A_REG | Y_REG | T_REG | CX_REG), /* ECX */
     (REGTYPE) 0,		/* EBX */
     (REGTYPE) 0,		/* ESI */
     (REGTYPE) 0,		/* EDI */

--- a/compiler/genx86.h
+++ b/compiler/genx86.h
@@ -36,9 +36,12 @@ typedef unsigned int FLAGS;
 #define	F_NOVALUE ((FLAGS) 32U)	/* dont need result value */
 #define	F_VOL	((FLAGS) 64U)	/* need value in scratch register */
 #define	F_NOEDI	((FLAGS) 128U)	/* do not use %edi and %esi */
-#define	F_NOECX	((FLAGS) 256U)	/* do not use %exc */
+#define	F_NOECX	((FLAGS) 256U)	/* do not use %ecx */
 #define	F_EAXEDX ((FLAGS) 512U)	/* result needed in %eax */
 #define	F_ECX	((FLAGS) 1024U)	/* use %ecx if a register is needed */
+#define	F_EDX	((FLAGS) 2048U)	/* use %edx if a register is needed */
+#define	F_EBX	((FLAGS) 4096U)	/* use %ebx if a register is needed */
+#define	F_EDI	((FLAGS) 8192U)	/* use %edi if a register is needed */
 
 #define F_ALL	((FLAGS)(F_DREG | F_AREG | F_MEM | F_IMMED | F_FREG))	/* any mode */
 
@@ -245,10 +248,13 @@ enum e_am
 #define	T_REG		((REGTYPE)8)	/* temporary register */
 #define	M_REG		((REGTYPE)16)	/* multiple data register */
 #define	X_REG		((REGTYPE)32)	/* AX/DX register */
-#define	Y_REG		((REGTYPE)64)	/* not AX/DX register */
-#define	C_REG		((REGTYPE)128)	/* CX data register */
-#define Z_REG		((REGTYPE)256)	/* AX data register */
-#define N_REG		((REGTYPE)512)	/* no CX data register */
+#define	Y_REG		((REGTYPE)64)	/* not AX/DX register UNUSED */
+#define N_REG		((REGTYPE)128)	/* no CX data register */
+#define CX_REG		((REGTYPE)256)	/* CX data register */
+#define AX_REG		((REGTYPE)512)	/* AX data register */
+#define DX_REG		((REGTYPE)1024)	/* DX data register */
+#define BX_REG		((REGTYPE)2048)	/* BX data register */
+#define DI_REG		((REGTYPE)4096)	/* DI address register */
 #define	is_data_register(r)		((regtypes[(int)r] & D_REG) != 0)
 #define	is_address_register(r)		((regtypes[(int)r] & A_REG) != 0)
 #define	is_float_register(r)		((regtypes[(int)r] & F_REG) != 0)
@@ -409,6 +415,9 @@ ADDRESS *address_register P_ ((void));
 ADDRESS *axdx_register P_ ((void));
 ADDRESS *ax_register P_ ((void));
 ADDRESS *cx_register P_ ((void));
+ADDRESS *dx_register P_ ((void));
+ADDRESS *bx_register P_ ((void));
+ADDRESS *di_register P_ ((void));
 ADDRESS *data_register P_ ((void));
 ADDRESS *data_register_no_cx P_ ((void));
 ADDRESS *mdata_register P_ ((void));

--- a/compiler/getsym.c
+++ b/compiler/getsym.c
@@ -478,6 +478,7 @@ void initsym P0 (void)
     sscanf_name = quick_insert ((const CHAR *) "sscanf", (SIZE) 6, tk_id);
     func_name = quick_insert ((const CHAR *) "__func__", (SIZE) 8, tk_id);
     main_name = quick_insert ((const CHAR *) "main", (SIZE) 4, tk_id);
+    loadreg_name = quick_insert ((const CHAR *) "__loadreg", (SIZE) 9, tk_id);
 
     /*
      *      Names used for pre-processor directives

--- a/compiler/outx86_as86.c
+++ b/compiler/outx86_as86.c
@@ -88,7 +88,7 @@ static SIZE align_type = 0L;
 static const char *prefix = ".L";   /* make labels temporary and not output to .o file  */
 static const char *comment = ";";
 
-static struct oplst
+struct oplst
 {
     const char *s;
     unsigned int sa;		/* special addressing modes:
@@ -391,7 +391,8 @@ static struct oplst
     "; Line", 0}
     ,				/* op_line */
     {
-    (char *) NULL, 0}		/* op_label */
+    "; Label", 0}
+				/* op_label */
 };
 
 /*****************************************************************************/

--- a/compiler/peepx86.c
+++ b/compiler/peepx86.c
@@ -580,11 +580,20 @@ static CODE *code P4 (OPCODE, op, ILEN, len, ADDRESS *, ap1, ADDRESS *, ap2)
     return ip;
 }
 
+#if DEBUG
+extern struct oplst
+{
+    const char *s;
+    unsigned int sa;
+} opl[];
+#endif
+
 /*
  * generate a code sequence into the peep list.
  */
 void g_code P4 (OPCODE, op, ILEN, len, ADDRESS *, ap1, ADDRESS *, ap2)
 {
+    debug("g_code op %d %s\n", op, opl[op].s);
     add_peep (code (op, len, ap1, ap2));
 }
 

--- a/compiler/regx86.c
+++ b/compiler/regx86.c
@@ -560,7 +560,7 @@ ADDRESS *axdx_register P0 (void)
 
 ADDRESS *cx_register P0 (void)
 {
-    printf("cx_register\n");
+    debug("cx_register\n");
     return temp_register (CX_REG | T_REG);
 }
 

--- a/compiler/regx86.c
+++ b/compiler/regx86.c
@@ -357,7 +357,7 @@ static REG next_reg P2 (REG, reg, REGTYPE, regtype)
     for (;;) {
 	if (reg > ST7) {
 	    reg = EAX;
-	    if (++loopcnt > 1)      /* ghaerr: will otherwise hang if no Z_REG in EAX */
+	    if (++loopcnt > 1)      /* ghaerr: will otherwise hang if no AX_REG in EAX */
 	        FATAL ((__FILE__, "next_reg", "INFINITE LOOP"));
 	}
 	if ((regtypes[reg] & regtype) == regtype) {
@@ -403,13 +403,16 @@ static void deallocate_register P1 (REG, reg)
     }
     switch (reg_alloc[depth].regtype) {
     case D_REG | T_REG:
+    case D_REG | T_REG | N_REG:
     case X_REG | T_REG:
-    case C_REG | T_REG:
-    case Z_REG | T_REG:
-    case D_REG | N_REG | T_REG:
+    case AX_REG | T_REG:
+    case CX_REG | T_REG:
+    case DX_REG | T_REG:
+    case BX_REG | T_REG:
 	next_dreg = reg_alloc[depth].next_reg;
 	break;
     case A_REG | T_REG:
+    case DI_REG | T_REG:
 	next_areg = reg_alloc[depth].next_reg;
 	break;
 #ifdef FLOAT_IEEE
@@ -459,7 +462,7 @@ static ADDRESS *temp_register P1 (REGTYPE, regtype)
 	next_dreg = (REG) ((int) reg + 1);
 	ap->mode = am_dreg;
 	break;
-    case D_REG | N_REG | T_REG:
+    case D_REG | T_REG | N_REG:
 	if (next_dreg == ECX) {
 	    next_dreg++;
 	}
@@ -494,17 +497,35 @@ static ADDRESS *temp_register P1 (REGTYPE, regtype)
 	next_freg = (REG) ((int) reg + 1);
 	ap->mode = am_freg;
 	break;
-    case C_REG | T_REG:
+    case AX_REG | T_REG:
+	reg = allocate_register (EAX, next_dreg, regtype);
+	ap = mk_reg (reg);
+	next_dreg = (REG) ((int) reg + 1);
+	ap->mode = am_dreg;
+	break;
+    case CX_REG | T_REG:
 	reg = allocate_register (ECX, next_dreg, regtype);
 	ap = mk_reg (reg);
 	next_dreg = (REG) ((int) reg + 1);
 	ap->mode = am_dreg;
 	break;
-    case Z_REG | T_REG:
-	reg = allocate_register (EAX, next_dreg, regtype);
+    case DX_REG | T_REG:
+	reg = allocate_register (EDX, next_dreg, regtype);
 	ap = mk_reg (reg);
 	next_dreg = (REG) ((int) reg + 1);
 	ap->mode = am_dreg;
+	break;
+    case BX_REG | T_REG:
+	reg = allocate_register (EBX, next_dreg, regtype);
+	ap = mk_reg (reg);
+	next_dreg = (REG) ((int) reg + 1);
+	ap->mode = am_dreg;
+	break;
+    case DI_REG | T_REG:
+	reg = allocate_register (EDI, next_areg, regtype);
+	ap = mk_reg (reg);
+	next_areg = (REG) ((int) reg + 1);
+	ap->mode = am_areg;
 	break;
     default:
 	CANNOT_REACH_HERE ();
@@ -529,7 +550,7 @@ ADDRESS *data_register_no_cx P0 (void)
 
 ADDRESS *ax_register P0 (void)
 {
-    return temp_register (Z_REG | T_REG);   /* ghaerr: requires Z_REG in reg_type[] */
+    return temp_register (AX_REG | T_REG);  /* ghaerr: requires AX_REG in reg_type[] */
 }
 
 ADDRESS *axdx_register P0 (void)
@@ -539,7 +560,23 @@ ADDRESS *axdx_register P0 (void)
 
 ADDRESS *cx_register P0 (void)
 {
-    return temp_register (C_REG | T_REG);
+    printf("cx_register\n");
+    return temp_register (CX_REG | T_REG);
+}
+
+ADDRESS *dx_register P0 (void)
+{
+    return temp_register (DX_REG | T_REG);
+}
+
+ADDRESS *bx_register P0 (void)
+{
+    return temp_register (BX_REG | T_REG);
+}
+
+ADDRESS *di_register P0 (void)
+{
+    return temp_register (DI_REG | T_REG);
 }
 
 /*

--- a/compiler/stmt.c
+++ b/compiler/stmt.c
@@ -986,6 +986,7 @@ void funcbody P2 (SYM *, sp, const BLOCK *, block)
 #endif /* ICODE */
 #ifdef CPU_DEFINED
 #ifdef DOINLINE
+    debug("is_inline %d = %d\n", is_inline(sp), inline_statement_cost(stmt));
     if (is_inline (sp) && (inline_statement_cost (stmt) < inline_option)) {
 	sp->value.stmt = copystmttree (stmt);
     } else

--- a/ecc
+++ b/ecc
@@ -36,6 +36,7 @@ CPPFLAGS="\
     $DEFINES                    \
     "
 
+# -trace=yes
 CFLAGS="\
     -g                          \
     -O                          \
@@ -48,7 +49,6 @@ CFLAGS="\
     -peep=all                   \
     -stackcheck=no              \
     -obsolete=yes               \
-    -trace=no                   \
     -icode                      \
     "
 

--- a/ecc
+++ b/ecc
@@ -47,6 +47,8 @@ CFLAGS="\
     -stackopt=minimum           \
     -peep=all                   \
     -stackcheck=no              \
+    -obsolete=yes               \
+    -trace=no                   \
     -icode                      \
     "
 


### PR DESCRIPTION
Adds first C86 builtin function `void __loadreg(int reg, int value)` which generates code to load the specified register with the passed value, which can be any expression. This will be used in the ELKS elkscmd/gui/vgalib.h VGA access macros to allow for non-constant (i.e. variable) values to be passed to ASM statements, like the OWC and IA16 compilers are able to.

Until now, there was no way in C86 to force-load any general register (AX, BX, CX, DX, SI or DI) with a non-constant value prior to compiling an `asm` statement. This restricted the use of register loads in asm statements to constant values, since macro expansion had to be used to insert a known value into the ASM string.

The register numbers will be added to the ELKS C library elks/include/arch/cdefs.h header file, since at this point C86 does not export any header files.

Some internal register flags were renamed in the code generator for better understanding (Z_REG -> AX_REG, C_REG -> CX_REG)

Also turns on `-obsolete=yes` option by default to warn users of deprecated C features, such as K&R prototypes, etc.