### PR TITLE
Fix C86 code generation when using 32-bit pre-inc/decrement within assignment

### DIFF
--- a/compiler/gen86.c
+++ b/compiler/gen86.c
@@ -1458,7 +1458,8 @@ static ADDRESS *g_asbin P3 (const EXPR *, ep, FLAGS, flags, OPCODE, op)
 	    /* void result */
 	    ap1 = NIL_ADDRESS;
 	} else {
-	    ap1 = g_expr (ep->v.p[0], (FLAGS) (flagx | F_DREG));
+	    /* ghaerr: replace F_DREG w/F_MEM to fix long a = ++l pre inc/decrement */
+	    ap1 = g_expr (ep->v.p[0], (FLAGS) (flagx | F_MEM));
 	    ap2 = g_expr (ep->v.p[1], (FLAGS) (flagx | F_ALL));
 	    validate (ap1);
 	    switch (op) {


### PR DESCRIPTION
Fixes the C86 bug found with the new C86 compiler test suite found in https://github.com/ghaerr/8086-toolchain/pull/70.

In particular, the following construct used to produce incorrect code (not saving the pre-incremented value):
```
long l, a;
int i, b;

void f(void)
{
    a = ++l;  // buggy w/long
    b = ++i;  // works w/int
}
```
Here's the test_cc test results after the fix:
```
# ./test_cc
C Compiler Test Suite

Operator Tests:
Line  Status   Test Performed                  High Low  = Result (expected)
 230: OK       20L + 3L                       $0000 0017 = 23
 233: OK       20L += 3L                      $0000 0017 = 23
 230: OK       20L + -3L                      $0000 0011 = 17
 233: OK       20L += -3L                     $0000 0011 = 17
 230: OK       -20L + 3L                      $ffff ffef = -17
 233: OK       -20L += 3L                     $ffff ffef = -17
 230: OK       -20L + -3L                     $ffff ffe9 = -23
 233: OK       -20L += -3L                    $ffff ffe9 = -23
 469: OK       20UL + 3UL                     $0000 0017 = 23
 472: OK       20UL += 3UL                    $0000 0017 = 23
 238: OK       20L - 3L                       $0000 0011 = 17
 241: OK       20L -= 3L                      $0000 0011 = 17
 238: OK       20L - -3L                      $0000 0017 = 23
 241: OK       20L -= -3L                     $0000 0017 = 23
 238: OK       -20L - 3L                      $ffff ffe9 = -23
 241: OK       -20L -= 3L                     $ffff ffe9 = -23
 238: OK       -20L - -3L                     $ffff ffef = -17
 241: OK       -20L -= -3L                    $ffff ffef = -17
 477: OK       20UL - 3UL                     $0000 0011 = 17
 480: OK       20UL -= 3UL                    $0000 0011 = 17
 246: OK       20L * 3L                       $0000 003c = 60
 249: OK       20L *= 3L                      $0000 003c = 60
 246: OK       20L * -3L                      $ffff ffc4 = -60
 249: OK       20L *= -3L                     $ffff ffc4 = -60
 246: OK       -20L * 3L                      $ffff ffc4 = -60
 249: OK       -20L *= 3L                     $ffff ffc4 = -60
 246: OK       -20L * -3L                     $0000 003c = 60
 249: OK       -20L *= -3L                    $0000 003c = 60
 485: OK       20UL * 3UL                     $0000 003c = 60
 488: OK       20UL *= 3UL                    $0000 003c = 60
 254: OK       20L / 3L                       $0000 0006 = 6
 257: OK       20L /= 3L                      $0000 0006 = 6
 254: OK       20L / -3L                      $ffff fffa = -6
 257: OK       20L /= -3L                     $ffff fffa = -6
 254: OK       -20L / 3L                      $ffff fffa = -6
 257: OK       -20L /= 3L                     $ffff fffa = -6
 254: OK       -20L / -3L                     $0000 0006 = 6
 257: OK       -20L /= -3L                    $0000 0006 = 6
 493: OK       20L / 3L                       $0000 0006 = 6
 496: OK       20L /= 3L                      $0000 0006 = 6
 262: OK       20L % 3L                       $0000 0002 = 2
 265: OK       20L %= 3L                      $0000 0002 = 2
 262: OK       20L % -3L                      $0000 0002 = 2
 265: OK       20L %= -3L                     $0000 0002 = 2
 262: OK       -20L % 3L                      $ffff fffe = -2
 265: OK       -20L %= 3L                     $ffff fffe = -2
 262: OK       -20L % -3L                     $ffff fffe = -2
 265: OK       -20L %= -3L                    $ffff fffe = -2
 501: OK       20UL % 3UL                     $0000 0002 = 2
 504: OK       20UL %= 3UL                    $0000 0002 = 2
 271: OK       20L < 3L                       $0000 0000 = 0
 274: OK       20L <= 3L                      $0000 0000 = 0
 271: OK       20L < -3L                      $0000 0000 = 0
 274: OK       20L <= -3L                     $0000 0000 = 0
 271: OK       -20L < 3L                      $0000 0001 = 1
 274: OK       -20L <= 3L                     $0000 0001 = 1
 271: OK       -20L < -3L                     $0000 0001 = 1
 274: OK       -20L <= -3L                    $0000 0001 = 1
 510: OK       20UL < 3UL                     $0000 0000 = 0
 513: OK       20UL <= 3UL                    $0000 0000 = 0
 279: OK       20L > 3L                       $0000 0001 = 1
 282: OK       20L >= 3L                      $0000 0001 = 1
 279: OK       20L > -3L                      $0000 0001 = 1
 282: OK       20L >= -3L                     $0000 0001 = 1
 279: OK       -20L > 3L                      $0000 0000 = 0
 282: OK       -20L >= 3L                     $0000 0000 = 0
 279: OK       -20L > -3L                     $0000 0000 = 0
 282: OK       -20L >= -3L                    $0000 0000 = 0
 518: OK       20UL > 3UL                     $0000 0001 = 1
 521: OK       20UL >= 3UL                    $0000 0001 = 1
 287: OK       20L == 3L                      $0000 0000 = 0
 287: OK       20L == -3L                     $0000 0000 = 0
 287: OK       -20L == 3L                     $0000 0000 = 0
 287: OK       -20L == -3L                    $0000 0000 = 0
 526: OK       20UL == 3UL                    $0000 0000 = 0
 292: OK       20L != 3L                      $0000 0001 = 1
 292: OK       20L != -3L                     $0000 0001 = 1
 292: OK       -20L != 3L                     $0000 0001 = 1
 292: OK       -20L != -3L                    $0000 0001 = 1
 531: OK       20UL != 3UL                    $0000 0001 = 1
 297: OK       20L && 3L                      $0000 0001 = 1
 297: OK       20L && -3L                     $0000 0001 = 1
 297: OK       -20L && 3L                     $0000 0001 = 1
 297: OK       -20L && -3L                    $0000 0001 = 1
 536: OK       20UL && 3UL                    $0000 0001 = 1
 302: OK       20L || 3L                      $0000 0001 = 1
 302: OK       20L || -3L                     $0000 0001 = 1
 302: OK       -20L || 3L                     $0000 0001 = 1
 302: OK       -20L || -3L                    $0000 0001 = 1
 541: OK       20UL || 3UL                    $0000 0001 = 1
 315: OK       20L - (unary)                  $ffff ffec = -20
 315: OK       20L - (unary)                  $ffff ffec = -20
 315: OK       -20L - (unary)                 $0000 0014 = 20
 315: OK       -20L - (unary)                 $0000 0014 = 20
 320: OK       20L ! (unary)                  $0000 0000 = 0
 320: OK       20L ! (unary)                  $0000 0000 = 0
 320: OK       -20L ! (unary)                 $0000 0000 = 0
 320: OK       -20L ! (unary)                 $0000 0000 = 0
 561: OK       20UL !                         $0000 0000 = 0
 325: OK       20L ++(post)                   $0000 0014 = 20
 328: OK       20L ++(post - unary)           $0000 0016 = 22
 325: OK       20L ++(post)                   $0000 0014 = 20
 328: OK       20L ++(post - unary)           $0000 0016 = 22
 325: OK       -20L ++(post)                  $ffff ffec = -20
 328: OK       -20L ++(post - unary)          $ffff ffee = -18
 325: OK       -20L ++(post)                  $ffff ffec = -20
 328: OK       -20L ++(post - unary)          $ffff ffee = -18
 566: OK       20UL ++(post)                  $0000 0014 = 20
 569: OK       20UL ++(post - unary)          $0000 0016 = 22
 333: OK       20L ++(pre)                    $0000 0015 = 21
 336: OK       20L ++(pre - unary)            $0000 0016 = 22
 333: OK       20L ++(pre)                    $0000 0015 = 21
 336: OK       20L ++(pre - unary)            $0000 0016 = 22
 333: OK       -20L ++(pre)                   $ffff ffed = -19
 336: OK       -20L ++(pre - unary)           $ffff ffee = -18
 333: OK       -20L ++(pre)                   $ffff ffed = -19
 336: OK       -20L ++(pre - unary)           $ffff ffee = -18
 574: OK       20UL ++(pre)                   $0000 0015 = 21
 577: OK       20UL ++(pre - unary)           $0000 0016 = 22
 341: OK       20L --(post)                   $0000 0014 = 20
 344: OK       20L --(post - unary)           $0000 0012 = 18
 341: OK       20L --(post)                   $0000 0014 = 20
 344: OK       20L --(post - unary)           $0000 0012 = 18
 341: OK       -20L --(post)                  $ffff ffec = -20
 344: OK       -20L --(post - unary)          $ffff ffea = -22
 341: OK       -20L --(post)                  $ffff ffec = -20
 344: OK       -20L --(post - unary)          $ffff ffea = -22
 582: OK       20UL --(post)                  $0000 0014 = 20
 585: OK       20UL --(post - unary)          $0000 0012 = 18
 349: OK       20L --(pre)                    $0000 0013 = 19
 352: OK       20L --(pre - unary)            $0000 0012 = 18
 349: OK       20L --(pre)                    $0000 0013 = 19
 352: OK       20L --(pre - unary)            $0000 0012 = 18
 349: OK       -20L --(pre)                   $ffff ffeb = -21
 352: OK       -20L --(pre - unary)           $ffff ffea = -22
 349: OK       -20L --(pre)                   $ffff ffeb = -21
 352: OK       -20L --(pre - unary)           $ffff ffea = -22
 590: OK       20UL --(pre)                   $0000 0013 = 19
 593: OK       20UL --(pre - unary)           $0000 0012 = 18
 358: OK       20L & 3L                       $0000 0000 = 0
 361: OK       20L &= 3L                      $0000 0000 = 0
 358: OK       20L & -3L                      $0000 0014 = 20
 361: OK       20L &= -3L                     $0000 0014 = 20
 358: OK       -20L & 3L                      $0000 0000 = 0
 361: OK       -20L &= 3L                     $0000 0000 = 0
 358: OK       -20L & -3L                     $ffff ffec = -20
 361: OK       -20L &= -3L                    $ffff ffec = -20
 599: OK       20UL & 3UL                     $0000 0000 = 0
 602: OK       20UL &= 3UL                    $0000 0000 = 0
 366: OK       20L | 3L                       $0000 0017 = 23
 369: OK       20L |= 3L                      $0000 0017 = 23
 366: OK       20L | -3L                      $ffff fffd = -3
 369: OK       20L |= -3L                     $ffff fffd = -3
 366: OK       -20L | 3L                      $ffff ffef = -17
 369: OK       -20L |= 3L                     $ffff ffef = -17
 366: OK       -20L | -3L                     $ffff fffd = -3
 369: OK       -20L |= -3L                    $ffff fffd = -3
 607: OK       20UL | 3UL                     $0000 0017 = 23
 610: OK       20UL |= 3UL                    $0000 0017 = 23
 374: OK       20L ^ 3L                       $0000 0017 = 23
 377: OK       20L ^= 3L                      $0000 0017 = 23
 374: OK       20L ^ -3L                      $ffff ffe9 = -23
 377: OK       20L ^= -3L                     $ffff ffe9 = -23
 374: OK       -20L ^ 3L                      $ffff ffef = -17
 377: OK       -20L ^= 3L                     $ffff ffef = -17
 374: OK       -20L ^ -3L                     $0000 0011 = 17
 377: OK       -20L ^= -3L                    $0000 0011 = 17
 615: OK       20UL ^ 3UL                     $0000 0017 = 23
 618: OK       20UL ^= 3UL                    $0000 0017 = 23
 382: OK       20L ~ (bitwise)                $ffff ffeb = -21
 382: OK       20L ~ (bitwise)                $ffff ffeb = -21
 382: OK       -20L ~ (bitwise)               $0000 0013 = 19
 382: OK       -20L ~ (bitwise)               $0000 0013 = 19
 623: OK       20UL ~                         $ffff ffeb = 65515
 388: OK       20L << 3L                      $0000 00a0 = 160
 391: OK       20L <<= 3L                     $0000 00a0 = 160
 388: OK       -20L << 3L                     $ffff ff60 = -160
 391: OK       -20L <<= 3L                    $ffff ff60 = -160
 629: OK       20UL << 3UL                    $0000 00a0 = 160
 632: OK       20UL <<= 3UL                   $0000 00a0 = 160
 397: OK       20L >> 3L                      $0000 0002 = 2
 400: OK       20L >>= 3L                     $0000 0002 = 2
 397: OK       -20L >> 3L                     $ffff fffd = -3
 400: OK       -20L >>= 3L                    $ffff fffd = -3
 638: OK       20UL >> 3UL                    $0000 0002 = 2
 641: OK       20UL >>= 3UL                   $0000 0002 = 2
 428: OK       20L cast from char             $0000 0014 = 20
 431: OK       20L cast from unsigned char    $0000 0014 = 20
 434: OK       20L cast from short            $0000 0014 = 20
 437: OK       20L cast from unsigned short   $0000 0014 = 20
 440: OK       20L cast from int              $0000 0014 = 20
 443: OK       20L cast from unsigned int     $0000 0014 = 20
 446: OK       20L cast from long             $0000 0014 = 20
 449: OK       20L cast from unsigned long    $0000 0014 = 20
 428: OK       20L cast from char             $0000 0014 = 20
 431: OK       20L cast from unsigned char    $0000 0014 = 20
 434: OK       20L cast from short            $0000 0014 = 20
 437: OK       20L cast from unsigned short   $0000 0014 = 20
 440: OK       20L cast from int              $0000 0014 = 20
 443: OK       20L cast from unsigned int     $0000 0014 = 20
 446: OK       20L cast from long             $0000 0014 = 20
 449: OK       20L cast from unsigned long    $0000 0014 = 20
 428: OK       -20L cast from char            $ffff ffec = -20
 431: OK       -20L cast from unsigned char   $0000 00ec = 236
 434: OK       -20L cast from short           $ffff ffec = -20
 437: OK       -20L cast from unsigned short  $0000 ffec = -20
 440: OK       -20L cast from int             $ffff ffec = -20
 443: OK       -20L cast from unsigned int    $0000 ffec = -20
 446: OK       -20L cast from long            $ffff ffec = -20
 449: OK       -20L cast from unsigned long   $ffff ffec = -20
 428: OK       -20L cast from char            $ffff ffec = -20
 431: OK       -20L cast from unsigned char   $0000 00ec = 236
 434: OK       -20L cast from short           $ffff ffec = -20
 437: OK       -20L cast from unsigned short  $0000 ffec = -20
 440: OK       -20L cast from int             $ffff ffec = -20
 443: OK       -20L cast from unsigned int    $0000 ffec = -20
 446: OK       -20L cast from long            $ffff ffec = -20
 449: OK       -20L cast from unsigned long   $ffff ffec = -20
 669: OK       20UL cast from char            $0000 0014 = 20
 672: OK       20UL cast from unsigned char   $0000 0014 = 20
 675: OK       20UL cast from short           $0000 0014 = 20
 678: OK       20UL cast from unsigned short  $0000 0014 = 20
 681: OK       20UL cast from int             $0000 0014 = 20
 684: OK       20UL cast from unsigned int    $0000 0014 = 20
 687: OK       20UL cast from long            $0000 0014 = 20
 690: OK       20UL cast from unsigned long   $0000 0014 = 20

TESTS COMPLETED
```